### PR TITLE
Enforced checking for Warnings in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Community version, including native images:
 mvn clean verify -Ptestsuite-community -Dquarkus.version=1.3.0.Final
 ```
 
+One can fine-tune excluded test cases or tests with ```excludeTags```, e.g. ```-DexcludeTags=startstop```.
+
 **Linux/Mac:**
 ```
 mvn clean verify -Ptestsuite

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
@@ -68,6 +68,8 @@ public class Logs {
     private static final Pattern startedPatternControlSymbols = Pattern.compile(".* started in .*188m([0-9\\.]+).*", Pattern.DOTALL);
     private static final Pattern stoppedPatternControlSymbols = Pattern.compile(".* stopped in .*188m([0-9\\.]+).*", Pattern.DOTALL);
 
+    private static final Pattern warnErrorDetectionPattern = Pattern.compile("(?i:.*(ERROR|WARN).*)");
+
     public static final long SKIP = -1L;
 
     // TODO: How about WARNING? Other unwanted messages?
@@ -75,7 +77,7 @@ public class Logs {
         try (Scanner sc = new Scanner(log)) {
             while (sc.hasNextLine()) {
                 String line = sc.nextLine();
-                boolean error = line.matches("(?i:.*ERROR.*)");
+                boolean error = warnErrorDetectionPattern.matcher(line).matches();
                 boolean whiteListed = false;
                 if (error) {
                     for (String w : app.whitelistLogLines.errs) {
@@ -86,7 +88,7 @@ public class Logs {
                         }
                     }
                 }
-                assertFalse(error && !whiteListed, cmd.name() + " log should not contain `ERROR' lines that are not whitelisted. " +
+                assertFalse(error && !whiteListed, cmd.name() + " log should not contain error or warning lines that are not whitelisted. " +
                         "See testsuite" + File.separator + "target" + File.separator + "archived-logs" +
                         File.separator + testClass + File.separator + testMethod + File.separator + log.getName());
             }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -33,12 +33,26 @@ public enum WhitelistLogLines {
     FULL_MICROPROFILE(new String[]{
             // Some artifacts names...
             "maven-error-diagnostics",
-            "errorprone"
+            "errorprone",
+            // Needs fixing in the demo app?
+            "TestSecureController.java",
     }),
     GENERATED_SKELETON(new String[]{
             // It so happens that the dummy skeleton tries to find Mongo. This is expected.
             // See app-generated-skeleton/README.md for explanation of the scope.
             "The remote computer refused the network connection",
+            // Harmless warning
+            "The Agroal dependency is present but no JDBC datasources have been defined",
+            // Due to our not exactly accurate application.properties, these expected warnings occur...
+            "Unrecognized configuration key \"quarkus.oidc.auth-server-url\" was provided",
+            "Unrecognized configuration key \"quarkus.oidc.client-id\" was provided",
+            "Unrecognized configuration key \"quarkus.smallrye-jwt.enabled\" was provided",
+            "Unrecognized configuration key \"quarkus.jaeger.service-name\" was provided",
+            "Unrecognized configuration key \"quarkus.jaeger.sampler-param\" was provided",
+            "Unrecognized configuration key \"quarkus.jaeger.endpoint\" was provided",
+            "Unrecognized configuration key \"quarkus.jaeger.sampler-type\" was provided",
+            // Hmm, weird, right? Deprecations should be fixed
+            "`io.vertx.reactivex.core.Vertx` is deprecated",
             // Some artifacts names...
             "maven-error-diagnostics",
             "errorprone"


### PR DESCRIPTION
@rsvoboda  Added checking for Warnings and whitelisted 1.3.1.Final warnings we have now... e.g. 

```
2020-04-02 15:35:00,336 WARN  [io.qua.ver.run.VertxProducer] (Quarkus Shutdown Thread)
 `io.vertx.reactivex.core.Vertx` is deprecated  and will be removed in a future version - 
it is recommended to switch to `io.vertx.mutiny.core.eventbus.Vertx`
```

