### PR TITLE
Partition included tests better

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,9 @@
         <junit.jupiter.version>5.6.0</junit.jupiter.version>
         <resteasy.version>4.3.0.Final</resteasy.version>
         <commons.lang.version>3.9</commons.lang.version>
+
+        <!-- Test to be executed by default (should be all of them) -->
+        <includeTags>generator,startstop,bomtests,codequarkus</includeTags>
     </properties>
 
     <profiles>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -67,7 +67,7 @@
                 <version>${maven.surefire.version}</version>
                 <configuration>
                     <!-- include -->
-                    <groups>generator,startstop,bomtests,codequarkus</groups>
+                    <groups>${includeTags}</groups>
                     <!-- exclude -->
                     <excludedGroups>${excludeTags}</excludedGroups>
                 </configuration>


### PR DESCRIPTION
Allows to execute just one thing at a time without enumerating exclusions, e.g. ``` -DincludeTags=codequarkus```