### PR TITLE
What I did report: Markdown description of test method and executed m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,40 @@ To examine logs yourself see ```./testsuite/target/archived-logs/``` , e.g.
 ./testsuite/target/archived-logs/io.quarkus.ts.startstop.StartStopTest/fullMicroProfileNative/native-build.log
 ./testsuite/target/archived-logs/io.quarkus.ts.startstop.StartStopTest/fullMicroProfileNative/native-run.log
 ```
+
+## What I Did Report
+
+The test suite records Maven commands it used, the directories where those commands were executed etc. in
+a neat markdown file for each test run. e.g.
+
+```
+# io.quarkus.ts.startstop.StartStopTest, jaxRsMinimalJVM
+/home/karm/workspaceRH/quarkus-startstop/app-jax-rs-minimal
+
+mvn clean compile quarkus:build -Dquarkus.package.output-name=quarkus -Dmaven.repo.local=/home/karm/QUARKUS/quarkus-1.3.2.CR1/maven-repository
+
+---
+/home/karm/workspaceRH/quarkus-startstop/app-jax-rs-minimal
+
+java -jar target/quarkus-runner.jar
+
+---
+Measurements:
+
+|App|Mode|buildTimeMs|timeToFirstOKRequestMs|startedInMs|stoppedInMs|RSSKb|FDs|
+| --- | --- | --- | --- | --- | --- | --- | --- |
+|JAX_RS_MINIMAL|JVM|4787|906|643|18|140504|162|
+
+```
+
+The file format is somewhat loose and it differs a bit test to test, it is meant for humans to take a quick look at what the TS did.
+If you need to machine process the data, we suggest: 
+ * capturing the TS stdout log where all commands are logged in a machine friendly format
+ * reading archived measurements.csv files
+
+One can also look into ```./testsuite/target/archived-logs/aggregated-report.md``` for an overall concatenation of all reports from all test runs.
+Subsequent test suite executions without ```mvn clean``` keep appending to this aggregate file on purpose. 
+
 ## Thresholds
 
 The test suite works with ```threshold.properties``` for each test app. E.g. ```app-jax-rs-minimal/threshold.properties```:

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.TestInfo;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -55,6 +56,7 @@ import static io.quarkus.ts.startstop.utils.Commands.processStopper;
 import static io.quarkus.ts.startstop.utils.Commands.runCommand;
 import static io.quarkus.ts.startstop.utils.Commands.waitForTcpClosed;
 import static io.quarkus.ts.startstop.utils.Logs.appendln;
+import static io.quarkus.ts.startstop.utils.Logs.appendlnSection;
 import static io.quarkus.ts.startstop.utils.Logs.archiveLog;
 import static io.quarkus.ts.startstop.utils.Logs.checkJarSuffixes;
 import static io.quarkus.ts.startstop.utils.Logs.checkLog;
@@ -103,9 +105,10 @@ public class ArtifactGeneratorBOMTest {
             generateLog = new File(logsDir + File.separator + "bom-artifact-generator.log");
             ExecutorService buildService = Executors.newFixedThreadPool(1);
             buildService.submit(new Commands.ProcessRunner(appBaseDir, generateLog, generatorCmd, 20));
-            appendln(whatIDidReport, "# " + cn + ", " + mn + "\n");
+            appendln(whatIDidReport, "# " + cn + ", " + mn);
+            appendln(whatIDidReport, (new Date()).toString());
             appendln(whatIDidReport, appBaseDir.getAbsolutePath());
-            appendln(whatIDidReport, String.join(" ", generatorCmd));
+            appendlnSection(whatIDidReport, String.join(" ", generatorCmd));
             buildService.shutdown();
             buildService.awaitTermination(30, TimeUnit.MINUTES);
 
@@ -121,7 +124,7 @@ public class ArtifactGeneratorBOMTest {
             buildService = Executors.newFixedThreadPool(1);
             buildService.submit(new Commands.ProcessRunner(appDir, buildLogA, buildCmd, 20));
             appendln(whatIDidReport, appDir.getAbsolutePath());
-            appendln(whatIDidReport, String.join(" ", buildCmd));
+            appendlnSection(whatIDidReport, String.join(" ", buildCmd));
             buildService.shutdown();
             buildService.awaitTermination(30, TimeUnit.MINUTES);
 
@@ -134,7 +137,7 @@ public class ArtifactGeneratorBOMTest {
             runLogA = new File(logsDir + File.separator + "bom-artifact-run.log");
             pA = runCommand(runCmd, appDir, runLogA);
             appendln(whatIDidReport, appDir.getAbsolutePath());
-            appendln(whatIDidReport, String.join(" ", runCmd));
+            appendlnSection(whatIDidReport, String.join(" ", runCmd));
 
             // Test web pages
             WebpageTester.testWeb(skeletonApp.urlContent[0][0], 20,

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
@@ -54,9 +54,11 @@ import static io.quarkus.ts.startstop.utils.Commands.parsePort;
 import static io.quarkus.ts.startstop.utils.Commands.processStopper;
 import static io.quarkus.ts.startstop.utils.Commands.runCommand;
 import static io.quarkus.ts.startstop.utils.Commands.waitForTcpClosed;
+import static io.quarkus.ts.startstop.utils.Logs.appendln;
 import static io.quarkus.ts.startstop.utils.Logs.archiveLog;
 import static io.quarkus.ts.startstop.utils.Logs.checkJarSuffixes;
 import static io.quarkus.ts.startstop.utils.Logs.checkLog;
+import static io.quarkus.ts.startstop.utils.Logs.writeReport;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -72,6 +74,7 @@ public class ArtifactGeneratorBOMTest {
         File generateLog = null;
         File buildLogA = null;
         File runLogA = null;
+        StringBuilder whatIDidReport = new StringBuilder();
         String cn = testInfo.getTestClass().get().getCanonicalName();
         String mn = testInfo.getTestMethod().get().getName();
         File appBaseDir = new File(getArtifactGeneBaseDir());
@@ -100,6 +103,9 @@ public class ArtifactGeneratorBOMTest {
             generateLog = new File(logsDir + File.separator + "bom-artifact-generator.log");
             ExecutorService buildService = Executors.newFixedThreadPool(1);
             buildService.submit(new Commands.ProcessRunner(appBaseDir, generateLog, generatorCmd, 20));
+            appendln(whatIDidReport, "# " + cn + ", " + mn + "\n");
+            appendln(whatIDidReport, appBaseDir.getAbsolutePath());
+            appendln(whatIDidReport, String.join(" ", generatorCmd));
             buildService.shutdown();
             buildService.awaitTermination(30, TimeUnit.MINUTES);
 
@@ -114,6 +120,8 @@ public class ArtifactGeneratorBOMTest {
             buildLogA = new File(logsDir + File.separator + "bom-artifact-build.log");
             buildService = Executors.newFixedThreadPool(1);
             buildService.submit(new Commands.ProcessRunner(appDir, buildLogA, buildCmd, 20));
+            appendln(whatIDidReport, appDir.getAbsolutePath());
+            appendln(whatIDidReport, String.join(" ", buildCmd));
             buildService.shutdown();
             buildService.awaitTermination(30, TimeUnit.MINUTES);
 
@@ -125,6 +133,8 @@ public class ArtifactGeneratorBOMTest {
             LOGGER.info("Running...");
             runLogA = new File(logsDir + File.separator + "bom-artifact-run.log");
             pA = runCommand(runCmd, appDir, runLogA);
+            appendln(whatIDidReport, appDir.getAbsolutePath());
+            appendln(whatIDidReport, String.join(" ", runCmd));
 
             // Test web pages
             WebpageTester.testWeb(skeletonApp.urlContent[0][0], 20,
@@ -157,6 +167,7 @@ public class ArtifactGeneratorBOMTest {
             if (runLogA != null) {
                 archiveLog(cn, mn, runLogA);
             }
+            writeReport(cn, mn, whatIDidReport.toString());
             cleanDirOrFile(appDir.getAbsolutePath(), logsDir);
         }
     }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -58,11 +58,13 @@ import static io.quarkus.ts.startstop.utils.Commands.processStopper;
 import static io.quarkus.ts.startstop.utils.Commands.runCommand;
 import static io.quarkus.ts.startstop.utils.Commands.waitForTcpClosed;
 import static io.quarkus.ts.startstop.utils.Logs.SKIP;
+import static io.quarkus.ts.startstop.utils.Logs.appendln;
 import static io.quarkus.ts.startstop.utils.Logs.archiveLog;
 import static io.quarkus.ts.startstop.utils.Logs.checkLog;
 import static io.quarkus.ts.startstop.utils.Logs.checkThreshold;
 import static io.quarkus.ts.startstop.utils.Logs.getLogsDir;
 import static io.quarkus.ts.startstop.utils.Logs.parseStartStopTimestamps;
+import static io.quarkus.ts.startstop.utils.Logs.writeReport;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -141,6 +143,7 @@ public class ArtifactGeneratorTest {
         Process pA = null;
         File buildLogA = null;
         File runLogA = null;
+        StringBuilder whatIDidReport = new StringBuilder();
         String cn = testInfo.getTestClass().get().getCanonicalName();
         String mn = testInfo.getTestMethod().get().getName();
         File appBaseDir = new File(getArtifactGeneBaseDir());
@@ -165,6 +168,9 @@ public class ArtifactGeneratorTest {
             buildLogA = new File(logsDir + File.separator + (flags.contains(TestFlags.WARM_UP) ? "warmup-artifact-build.log" : "artifact-build.log"));
             ExecutorService buildService = Executors.newFixedThreadPool(1);
             buildService.submit(new Commands.ProcessRunner(appBaseDir, buildLogA, generatorCmd, 20));
+            appendln(whatIDidReport, "# " + cn + ", " + mn + ", warmup run: " + flags.contains(TestFlags.WARM_UP) + "\n");
+            appendln(whatIDidReport, appBaseDir.getAbsolutePath());
+            appendln(whatIDidReport, String.join(" ", generatorCmd));
             long buildStarts = System.currentTimeMillis();
             buildService.shutdown();
             buildService.awaitTermination(30, TimeUnit.MINUTES);
@@ -180,7 +186,8 @@ public class ArtifactGeneratorTest {
             LOGGER.info("Running...");
             runLogA = new File(logsDir + File.separator + (flags.contains(TestFlags.WARM_UP) ? "warmup-dev-run.log" : "dev-run.log"));
             pA = runCommand(runCmd, appDir, runLogA);
-
+            appendln(whatIDidReport, appDir.getAbsolutePath());
+            appendln(whatIDidReport, String.join(" ", runCmd));
             // Test web pages
             // The reason for a seemingly large timeout of 20 minutes is that dev mode will be downloading the Internet on the first fresh run.
             long timeoutS = (flags.contains(TestFlags.WARM_UP) ? 20 * 60 : 60);
@@ -200,9 +207,9 @@ public class ArtifactGeneratorTest {
             }
 
             LOGGER.info("Testing reload...");
-
             Path srcFile = Paths.get(appDir + File.separator + "src" + File.separator + "main" + File.separator + "java" + File.separator +
                     "org" + File.separator + "my" + File.separator + "group" + File.separator + "MyResource.java");
+            appendln(whatIDidReport, "Reloading class: " + srcFile.toAbsolutePath());
             try (Stream<String> src = Files.lines(srcFile)) {
                 Files.write(srcFile, src.map(l -> l.replaceAll("hello", "bye")).collect(Collectors.toList()));
             }
@@ -252,6 +259,7 @@ public class ArtifactGeneratorTest {
                 // If build failed it is actually expected to have no runtime log.
                 archiveLog(cn, mn, runLogA);
             }
+            writeReport(cn, mn, whatIDidReport.toString());
             cleanDirOrFile(appDir.getAbsolutePath(), logsDir);
         }
     }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -43,8 +43,10 @@ import static io.quarkus.ts.startstop.utils.Commands.processStopper;
 import static io.quarkus.ts.startstop.utils.Commands.runCommand;
 import static io.quarkus.ts.startstop.utils.Commands.unzip;
 import static io.quarkus.ts.startstop.utils.Commands.waitForTcpClosed;
+import static io.quarkus.ts.startstop.utils.Logs.appendln;
 import static io.quarkus.ts.startstop.utils.Logs.archiveLog;
 import static io.quarkus.ts.startstop.utils.Logs.checkLog;
+import static io.quarkus.ts.startstop.utils.Logs.writeReport;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -65,6 +67,7 @@ public class CodeQuarkusTest {
         Process pA = null;
         File unzipLog = null;
         File runLogA = null;
+        StringBuilder whatIDidReport = new StringBuilder();
         String cn = testInfo.getTestClass().get().getCanonicalName();
         String mn = testInfo.getTestMethod().get().getName();
         LOGGER.info(mn + ": Testing Code Quarkus generator with these " + extensions.size() + " extensions: " + extensions.toString());
@@ -83,6 +86,10 @@ public class CodeQuarkusTest {
             unzipLog = unzip(zipFile, GEN_BASE_DIR);
             runLogA = new File(logsDir + File.separator + "dev-run.log");
             LOGGER.info("Running command: " + devCmd + " in directory: " + appDir);
+            appendln(whatIDidReport, "# " + cn + ", " + mn + "\n");
+            appendln(whatIDidReport, "Extensions: " + extensions.toString());
+            appendln(whatIDidReport, appDir.getAbsolutePath());
+            appendln(whatIDidReport, String.join(" ", devCmd));
             pA = runCommand(devCmd, appDir, runLogA);
             // It takes time to download the Internet
             long timeoutS = 10 * 60;
@@ -101,6 +108,7 @@ public class CodeQuarkusTest {
             }
             archiveLog(cn, mn, unzipLog);
             archiveLog(cn, mn, runLogA);
+            writeReport(cn, mn, whatIDidReport.toString());
             cleanDirOrFile(appDir.getAbsolutePath(), logsDir);
         }
     }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.TestInfo;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -44,6 +45,7 @@ import static io.quarkus.ts.startstop.utils.Commands.runCommand;
 import static io.quarkus.ts.startstop.utils.Commands.unzip;
 import static io.quarkus.ts.startstop.utils.Commands.waitForTcpClosed;
 import static io.quarkus.ts.startstop.utils.Logs.appendln;
+import static io.quarkus.ts.startstop.utils.Logs.appendlnSection;
 import static io.quarkus.ts.startstop.utils.Logs.archiveLog;
 import static io.quarkus.ts.startstop.utils.Logs.checkLog;
 import static io.quarkus.ts.startstop.utils.Logs.writeReport;
@@ -80,16 +82,17 @@ public class CodeQuarkusTest {
         try {
             cleanDirOrFile(appDir.getAbsolutePath(), logsDir);
             Files.createDirectories(Paths.get(logsDir));
+            appendln(whatIDidReport, "# " + cn + ", " + mn);
+            appendln(whatIDidReport, (new Date()).toString());
             LOGGER.info("Downloading...");
-            download(extensions, zipFile);
+            appendln(whatIDidReport, "Download URL: " + download(extensions, zipFile));
             LOGGER.info("Unzipping...");
             unzipLog = unzip(zipFile, GEN_BASE_DIR);
             runLogA = new File(logsDir + File.separator + "dev-run.log");
             LOGGER.info("Running command: " + devCmd + " in directory: " + appDir);
-            appendln(whatIDidReport, "# " + cn + ", " + mn + "\n");
             appendln(whatIDidReport, "Extensions: " + extensions.toString());
             appendln(whatIDidReport, appDir.getAbsolutePath());
-            appendln(whatIDidReport, String.join(" ", devCmd));
+            appendlnSection(whatIDidReport, String.join(" ", devCmd));
             pA = runCommand(devCmd, appDir, runLogA);
             // It takes time to download the Internet
             long timeoutS = 10 * 60;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -52,6 +53,7 @@ import static io.quarkus.ts.startstop.utils.Commands.runCommand;
 import static io.quarkus.ts.startstop.utils.Commands.waitForTcpClosed;
 import static io.quarkus.ts.startstop.utils.Logs.SKIP;
 import static io.quarkus.ts.startstop.utils.Logs.appendln;
+import static io.quarkus.ts.startstop.utils.Logs.appendlnSection;
 import static io.quarkus.ts.startstop.utils.Logs.archiveLog;
 import static io.quarkus.ts.startstop.utils.Logs.checkLog;
 import static io.quarkus.ts.startstop.utils.Logs.checkThreshold;
@@ -90,9 +92,10 @@ public class StartStopTest {
             ExecutorService buildService = Executors.newFixedThreadPool(1);
             List<String> cmd = getBuildCommand(mvnCmds.mvnCmds[0]);
             buildService.submit(new Commands.ProcessRunner(appDir, buildLogA, cmd, 20));
-            appendln(whatIDidReport, "# " + cn + ", " + mn + "\n");
+            appendln(whatIDidReport, "# " + cn + ", " + mn);
+            appendln(whatIDidReport, (new Date()).toString());
             appendln(whatIDidReport, appDir.getAbsolutePath());
-            appendln(whatIDidReport, String.join(" ", cmd));
+            appendlnSection(whatIDidReport, String.join(" ", cmd));
             long buildStarts = System.currentTimeMillis();
             buildService.shutdown();
             buildService.awaitTermination(30, TimeUnit.MINUTES);
@@ -107,7 +110,7 @@ public class StartStopTest {
             cmd = getRunCommand(mvnCmds.mvnCmds[1]);
             pA = runCommand(cmd, appDir, runLogA);
             appendln(whatIDidReport, appDir.getAbsolutePath());
-            appendln(whatIDidReport, String.join(" ", cmd));
+            appendlnSection(whatIDidReport, String.join(" ", cmd));
             // Test web pages
             long timeToFirstOKRequest = WebpageTester.testWeb(app.urlContent.urlContent[0][0], 10, app.urlContent.urlContent[0][1], true);
             LOGGER.info("Testing web page content...");
@@ -143,9 +146,9 @@ public class StartStopTest {
                     .openedFiles(openedFiles)
                     .build();
             Logs.logMeasurements(log, measurementsLog);
-
+            appendln(whatIDidReport, "Measurements:");
+            appendln(whatIDidReport, log.headerMarkdown + "\n" + log.lineMarkdown);
             checkThreshold(app, mvnCmds, rssKb, timeToFirstOKRequest, SKIP);
-
         } finally {
             // Make sure processes are down even if there was an exception / failure
             if (pA != null) {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -266,13 +266,23 @@ public class Commands {
         return Collections.unmodifiableList(generatorCmd);
     }
 
-    public static void download(Collection<CodeQuarkusExtensions> extensions, String destinationZipFile) throws IOException {
+    /**
+     * Download a zip file with an example project
+     *
+     * @param extensions         collection of extension codes, @See {@link io.quarkus.ts.startstop.utils.CodeQuarkusExtensions}
+     * @param destinationZipFile path where the zip file will be written
+     * @return the actual URL used for audit and logging purposes
+     * @throws IOException
+     */
+    public static String download(Collection<CodeQuarkusExtensions> extensions, String destinationZipFile) throws IOException {
+        String downloadURL = getCodeQuarkusURL() + "/api/download?s=" +
+                extensions.stream().map(x -> x.shortId).collect(Collectors.joining("."));
         try (ReadableByteChannel readableByteChannel = Channels.newChannel(
-                new URL(getCodeQuarkusURL() + "/api/download?s=" +
-                        extensions.stream().map(x -> x.shortId).collect(Collectors.joining("."))).openStream());
+                new URL(downloadURL).openStream());
              FileChannel fileChannel = new FileOutputStream(destinationZipFile).getChannel()) {
             fileChannel.transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
         }
+        return downloadURL;
     }
 
     public static File unzip(String zipFilePath, String destinationDir) throws InterruptedException, IOException {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/LogBuilder.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/LogBuilder.java
@@ -27,12 +27,16 @@ import java.util.Objects;
 public class LogBuilder {
 
     public static class Log {
-        public final String header;
-        public final String line;
+        public final String headerCSV;
+        public final String headerMarkdown;
+        public final String lineCSV;
+        public final String lineMarkdown;
 
-        public Log(String header, String line) {
-            this.header = header;
-            this.line = line;
+        public Log(String headerCSV, String headerMarkdown, String lineCSV, String lineMarkdown) {
+            this.headerCSV = headerCSV;
+            this.headerMarkdown = headerMarkdown;
+            this.lineCSV = lineCSV;
+            this.lineMarkdown = lineMarkdown;
         }
     }
 
@@ -126,63 +130,77 @@ public class LogBuilder {
     public Log build() {
         StringBuilder h = new StringBuilder(512);
         StringBuilder l = new StringBuilder(512);
+        int sections = 0;
         if (app != null) {
             h.append(appHeader);
             h.append(',');
             l.append(app);
             l.append(',');
+            sections++;
         }
         if (mode != null) {
             h.append(modeHeader);
             h.append(',');
             l.append(mode);
             l.append(',');
+            sections++;
         }
         if (buildTimeMs != -1L) {
             h.append(buildTimeMsHeader);
             h.append(',');
             l.append(buildTimeMs);
             l.append(',');
+            sections++;
         }
         if (timeToFirstOKRequestMs != -1L) {
             h.append(timeToFirstOKRequestMsHeader);
             h.append(',');
             l.append(timeToFirstOKRequestMs);
             l.append(',');
+            sections++;
         }
         if (timeToReloadedOKRequest != -1L) {
             h.append(timeToReloadedOKRequestHeader);
             h.append(',');
             l.append(timeToReloadedOKRequest);
             l.append(',');
+            sections++;
         }
         if (startedInMs != -1L) {
             h.append(startedInMsHeader);
             h.append(',');
             l.append(startedInMs);
             l.append(',');
+            sections++;
         }
         if (stoppedInMs != -1L) {
             h.append(stoppedInMsHeader);
             h.append(',');
             l.append(stoppedInMs);
             l.append(',');
+            sections++;
         }
         if (rssKb != -1L) {
             h.append(rssKbHeader);
             h.append(',');
             l.append(rssKb);
             l.append(',');
+            sections++;
         }
         if (openedFiles != -1L) {
             h.append(openedFilesHeader);
             h.append(',');
             l.append(openedFiles);
             l.append(',');
+            sections++;
         }
         String header = h.toString();
+        // Strip trailing ',' for CSV
+        String headerCSV = header.substring(0, header.length() - 1);
+        String headerMarkdown = "|" + header.replaceAll(",", "|") + "\n|" + " --- |".repeat(sections);
         String line = l.toString();
-        // Strip trailing ','
-        return new Log(header.substring(0, header.length() - 1), line.substring(0, line.length() - 1));
+        String lineCSV = line.substring(0, line.length() - 1);
+        String lineMarkdown = "|" + line.replaceAll(",", "|");
+        return new Log(headerCSV, headerMarkdown, lineCSV, lineMarkdown);
     }
 }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
@@ -124,7 +124,7 @@ public class Logs {
             }
             assertFalse(containsNotWhitelisted, "There are not-whitelisted artifacts without expected string " + jarSuffix + " suffix, see: \n"
                     + String.join("\n", reportArtifacts));
-            if(!reportArtifacts.isEmpty()) {
+            if (!reportArtifacts.isEmpty()) {
                 LOGGER.warning("There are whitelisted artifacts without expected string " + jarSuffix + " suffix, see: \n"
                         + String.join("\n", reportArtifacts));
             }
@@ -181,6 +181,17 @@ public class Logs {
         Files.createDirectories(destDir);
         String filename = log.getName();
         Files.copy(log.toPath(), Paths.get(destDir.toString(), filename));
+    }
+
+    public static void writeReport(String testClass, String testMethod, String text) throws IOException {
+        Path destDir = getLogsDir(testClass, testMethod);
+        Files.createDirectories(destDir);
+        Files.write(Paths.get(destDir.toString(), "report.md"), text.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
+    }
+
+    public static void appendln(StringBuilder s, String text) {
+        s.append(text);
+        s.append("\n");
     }
 
     public static Path getLogsDir(String testClass, String testMethod) throws IOException {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang3.StringUtils;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -41,6 +40,8 @@ import java.util.stream.Collectors;
 
 import static io.quarkus.ts.startstop.StartStopTest.BASE_DIR;
 import static io.quarkus.ts.startstop.utils.Commands.isThisWindows;
+import static java.nio.charset.StandardCharsets.*;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -180,18 +181,31 @@ public class Logs {
         Path destDir = getLogsDir(testClass, testMethod);
         Files.createDirectories(destDir);
         String filename = log.getName();
-        Files.copy(log.toPath(), Paths.get(destDir.toString(), filename));
+        Files.copy(log.toPath(), Paths.get(destDir.toString(), filename), REPLACE_EXISTING);
     }
 
     public static void writeReport(String testClass, String testMethod, String text) throws IOException {
         Path destDir = getLogsDir(testClass, testMethod);
         Files.createDirectories(destDir);
-        Files.write(Paths.get(destDir.toString(), "report.md"), text.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
+        Files.write(Paths.get(destDir.toString(), "report.md"), text.getBytes(UTF_8), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        Path agregateReport = Paths.get(getLogsDir().toString(), "aggregated-report.md");
+        if (Files.notExists(agregateReport)) {
+            Files.write(agregateReport, ("# Aggregated Report\n\n").getBytes(UTF_8), StandardOpenOption.CREATE);
+        }
+        Files.write(agregateReport, text.getBytes(UTF_8), StandardOpenOption.APPEND);
     }
 
+    /**
+     * Markdown needs two newlines to make a new paragraph.
+     */
     public static void appendln(StringBuilder s, String text) {
         s.append(text);
-        s.append("\n");
+        s.append("\n\n");
+    }
+
+    public static void appendlnSection(StringBuilder s, String text) {
+        s.append(text);
+        s.append("\n\n---\n");
     }
 
     public static Path getLogsDir(String testClass, String testMethod) throws IOException {
@@ -201,18 +215,24 @@ public class Logs {
     }
 
     public static Path getLogsDir(String testClass) throws IOException {
+        Path destDir = new File(getLogsDir().toString() + File.separator + testClass).toPath();
+        Files.createDirectories(destDir);
+        return destDir;
+    }
+
+    public static Path getLogsDir() throws IOException {
         Path destDir = new File(BASE_DIR + File.separator + "testsuite" + File.separator + "target" +
-                File.separator + "archived-logs" + File.separator + testClass).toPath();
+                File.separator + "archived-logs").toPath();
         Files.createDirectories(destDir);
         return destDir;
     }
 
     public static void logMeasurements(LogBuilder.Log log, Path path) throws IOException {
         if (Files.notExists(path)) {
-            Files.write(path, (log.header + "\n").getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
+            Files.write(path, (log.headerCSV + "\n").getBytes(UTF_8), StandardOpenOption.CREATE);
         }
-        Files.write(path, (log.line + "\n").getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
-        LOGGER.info("\n" + log.header + "\n" + log.line);
+        Files.write(path, (log.lineCSV + "\n").getBytes(UTF_8), StandardOpenOption.APPEND);
+        LOGGER.info("\n" + log.headerCSV + "\n" + log.lineCSV);
     }
 
     /**


### PR DESCRIPTION
…aven commands to make reproducing easier

```
./testsuite/target/archived-logs/io.quarkus.ts.startstop.StartStopTest/jaxRsMinimalNative/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.StartStopTest/fullMicroProfileJVM/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.StartStopTest/jaxRsMinimalJVM/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.StartStopTest/fullMicroProfileNative/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.CodeQuarkusTest/supportedExtensionsSubsetD/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.CodeQuarkusTest/mixExtensions/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.CodeQuarkusTest/supportedExtensionsSubsetA/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.CodeQuarkusTest/supportedExtensionsSubsetB/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.CodeQuarkusTest/notsupportedExtensionsSubset/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.CodeQuarkusTest/supportedExtensionsSubsetC/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.ArtifactGeneratorBOMTest/quarkusUniverseBomExtensionsB/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.ArtifactGeneratorBOMTest/quarkusUniverseProductBomExtensionsB/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.ArtifactGeneratorBOMTest/quarkusProductBomExtensionsB/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.ArtifactGeneratorBOMTest/quarkusBomExtensionsA/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.ArtifactGeneratorBOMTest/quarkusUniverseProductBomExtensionsA/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.ArtifactGeneratorBOMTest/quarkusBomExtensionsB/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.ArtifactGeneratorBOMTest/quarkusProductBomExtensionsA/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.ArtifactGeneratorBOMTest/quarkusUniverseBomExtensionsA/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.ArtifactGeneratorTest/manyExtensionsSetB/report.md
./testsuite/target/archived-logs/io.quarkus.ts.startstop.ArtifactGeneratorTest/manyExtensionsSetA/report.md
```

e.g. 

```
# io.quarkus.ts.startstop.ArtifactGeneratorTest, manyExtensionsSetB, warmup run: false

/tmp
mvn io.quarkus:quarkus-maven-plugin:1.3.2.Final-redhat-00001:create -DprojectGroupId=my-groupId -DprojectArtifactId=app-generated-skeleton -DprojectVersion=1.0.0-SNAPSHOT -DclassName=org.my.group.MyResource -Dextensions=agroal,config-yaml,core,hibernate-orm,hibernate-orm-panache,hibernate-validator,jackson,jaxb,jdbc-mariadb,jdbc-mssql,smallrye-context-propagation,smallrye-fault-tolerance,smallrye-health,smallrye-jwt,smallrye-metrics,smallrye-openapi,smallrye-opentracing,smallrye-reactive-messaging,smallrye-reactive-messaging-kafka,smallrye-reactive-streams-operators,spring-data-jpa,spring-di,spring-security,spring-web -Dmaven.repo.local=/home/karm/QUARKUS/quarkus-1.3.2.CR1/maven-repository
/tmp/app-generated-skeleton
mvn clean quarkus:dev
Reloading class: /tmp/app-generated-skeleton/src/main/java/org/my/group/MyResource.java
```

or 

```
# io.quarkus.ts.startstop.ArtifactGeneratorBOMTest, quarkusUniverseProductBomExtensionsA

/tmp
mvn io.quarkus:quarkus-maven-plugin:1.3.2.Final-redhat-00001:create -DprojectGroupId=my-groupId -DprojectArtifactId=app-generated-skeleton -DprojectVersion=1.0.0-SNAPSHOT -DclassName=org.my.group.MyResource -DplatformArtifactId=quarkus-universe-bom -DplatformGroupId=com.redhat.quarkus -DplatformVersion=1.3.2.Final-redhat-00001 -Dextensions=agroal,config-yaml,core,hibernate-orm,hibernate-orm-panache,hibernate-validator,jackson,jaxb,jdbc-mysql,jdbc-postgresql,jsonb,jsonp,kafka-client,logging-json,narayana-jta,oidc,quartz,reactive-pg-client,rest-client,resteasy,resteasy-jackson,resteasy-jaxb,resteasy-jsonb,scheduler,spring-boot-properties,smallrye-reactive-messaging-amqp,spring-data-jpa,spring-di,spring-security,spring-web,undertow,undertow-websockets,vertx,vertx-web -Dmaven.repo.local=/home/karm/QUARKUS/quarkus-1.3.2.CR1/maven-repository --settings=/home/karm/workspaceRH/quarkus-startstop/app-generated-skeleton/settings.xml
/tmp/app-generated-skeleton
mvn clean compile quarkus:build -Dquarkus.package.output-name=quarkus -Dmaven.repo.local=/home/karm/QUARKUS/quarkus-1.3.2.CR1/maven-repository --settings=/home/karm/workspaceRH/quarkus-startstop/app-generated-skeleton/settings.xml
/tmp/app-generated-skeleton
java -jar target/quarkus-runner.jar
```

or

```
# io.quarkus.ts.startstop.CodeQuarkusTest, mixExtensions

Extensions: [QUARKUS_RESTEASY, QUARKUS_RESTEASY_JSONB, QUARKUS_RESTEASY_JACKSON, QUARKUS_VERTX_WEB, QUARKUS_HIBERNATE_VALIDATOR, QUARKUS_REST_CLIENT, QUARKUS_RESTEASY_JAXB, QUARKUS_RESTEASY_MUTINY, QUARKUS_RESTEASY_QUTE, QUARKUS_SMALLRYE_OPENAPI, QUARKUS_UNDERTOW, QUARKUS_UNDERTOW_WEBSOCKETS, QUARKUS_HIBERNATE_ORM, QUARKUS_HIBERNATE_ORM_PANACHE, QUARKUS_JDBC_POSTGRESQL]
/tmp/code-with-quarkus
./mvnw quarkus:dev -Dmaven.repo.local=/home/karm/QUARKUS/quarkus-1.3.2.CR1/maven-repository
```