### PR TITLE
jboss-logging with log4j2, colorized console log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,30 @@
         <junit.jupiter.version>5.6.0</junit.jupiter.version>
         <resteasy.version>4.3.0.Final</resteasy.version>
         <commons.lang.version>3.9</commons.lang.version>
+        <jboss-logging.version>3.4.1.Final</jboss-logging.version>
+        <log4j.version>2.13.2</log4j.version>
 
         <!-- Test to be executed by default (should be all of them) -->
         <includeTags>generator,startstop,bomtests,codequarkus</includeTags>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>${jboss-logging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+    </dependencies>
 
     <profiles>
         <profile>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
@@ -26,6 +26,7 @@ import io.quarkus.ts.startstop.utils.MvnCmds;
 import io.quarkus.ts.startstop.utils.TestFlags;
 import io.quarkus.ts.startstop.utils.URLContent;
 import io.quarkus.ts.startstop.utils.WebpageTester;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -40,7 +41,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 import static io.quarkus.ts.startstop.ArtifactGeneratorTest.supportedExtensionsSubsetSetA;
 import static io.quarkus.ts.startstop.ArtifactGeneratorTest.supportedExtensionsSubsetSetB;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -28,6 +28,7 @@ import io.quarkus.ts.startstop.utils.MvnCmds;
 import io.quarkus.ts.startstop.utils.TestFlags;
 import io.quarkus.ts.startstop.utils.URLContent;
 import io.quarkus.ts.startstop.utils.WebpageTester;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -43,7 +44,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -24,6 +24,7 @@ import io.quarkus.ts.startstop.utils.CodeQuarkusExtensions;
 import io.quarkus.ts.startstop.utils.MvnCmds;
 import io.quarkus.ts.startstop.utils.URLContent;
 import io.quarkus.ts.startstop.utils.WebpageTester;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -33,7 +34,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Date;
 import java.util.List;
-import java.util.logging.Logger;
 
 import static io.quarkus.ts.startstop.utils.Commands.cleanDirOrFile;
 import static io.quarkus.ts.startstop.utils.Commands.download;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
@@ -25,6 +25,7 @@ import io.quarkus.ts.startstop.utils.LogBuilder;
 import io.quarkus.ts.startstop.utils.Logs;
 import io.quarkus.ts.startstop.utils.MvnCmds;
 import io.quarkus.ts.startstop.utils.WebpageTester;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -39,7 +40,6 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 import static io.quarkus.ts.startstop.utils.Commands.cleanTarget;
 import static io.quarkus.ts.startstop.utils.Commands.getBaseDir;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -21,6 +21,7 @@ package io.quarkus.ts.startstop.utils;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jboss.logging.Logger;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -49,7 +50,6 @@ import java.util.Objects;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -106,7 +106,7 @@ public class Commands {
                 return sys;
             }
         }
-        LOGGER.warning("Failed to detect quarkus.platform.version/QUARKUS_PLATFORM_VERSION, defaulting to getQuarkusVersion().");
+        LOGGER.warn("Failed to detect quarkus.platform.version/QUARKUS_PLATFORM_VERSION, defaulting to getQuarkusVersion().");
         return getQuarkusVersion();
     }
 
@@ -164,7 +164,7 @@ public class Commands {
         }
         if (url == null) {
             url = "https://code.quarkus.io";
-            LOGGER.warning("Failed to detect code.quarkus.url/CODE_QUARKUS_URL env/sys props, defaulting to " + url);
+            LOGGER.warn("Failed to detect code.quarkus.url/CODE_QUARKUS_URL env/sys props, defaulting to " + url);
             return url;
         }
         Matcher m = trailingSlash.matcher(url);
@@ -370,7 +370,7 @@ public class Commands {
                 Runtime.getRuntime().exec(new String[]{"kill", force ? "-9" : "-15", Long.toString(pid)});
             }
         } catch (IOException | InterruptedException e) {
-            LOGGER.severe(e.getMessage());
+            LOGGER.error(e.getMessage(), e);
         }
     }
 

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/FakeOIDCServer.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/FakeOIDCServer.java
@@ -19,6 +19,8 @@
  */
 package io.quarkus.ts.startstop.utils;
 
+import org.jboss.logging.Logger;
+
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -27,7 +29,6 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Logger;
 
 /**
  * @author Michal Karm Babacek <karm@redhat.com>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
@@ -20,6 +20,7 @@
 package io.quarkus.ts.startstop.utils;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jboss.logging.Logger;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -33,7 +34,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -126,7 +126,7 @@ public class Logs {
             assertFalse(containsNotWhitelisted, "There are not-whitelisted artifacts without expected string " + jarSuffix + " suffix, see: \n"
                     + String.join("\n", reportArtifacts));
             if (!reportArtifacts.isEmpty()) {
-                LOGGER.warning("There are whitelisted artifacts without expected string " + jarSuffix + " suffix, see: \n"
+                LOGGER.warn("There are whitelisted artifacts without expected string " + jarSuffix + " suffix, see: \n"
                         + String.join("\n", reportArtifacts));
             }
         }
@@ -169,7 +169,7 @@ public class Logs {
 
     public static void archiveLog(String testClass, String testMethod, File log) throws IOException {
         if (log == null || !log.exists()) {
-            LOGGER.severe("log must be a valid, existing file. Skipping operation.");
+            LOGGER.warn("log must be a valid, existing file. Skipping operation.");
             return;
         }
         if (StringUtils.isBlank(testClass)) {
@@ -282,12 +282,12 @@ public class Logs {
             }
         }
         if (startedStopped[0] == -1f) {
-            LOGGER.severe("Parsing start time from log failed. " +
+            LOGGER.error("Parsing start time from log failed. " +
                     "Might not be the right time to call this method. The process might have ben killed before it wrote to log." +
                     "Find " + log.getName() + " in your target dir.");
         }
         if (startedStopped[1] == -1f) {
-            LOGGER.severe("Parsing stop time from log failed. " +
+            LOGGER.error("Parsing stop time from log failed. " +
                     "Might not be the right time to call this method. The process might have been killed before it wrote to log." +
                     "Find " + log.getName() + " in your target dir.");
         }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WebpageTester.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WebpageTester.java
@@ -20,13 +20,13 @@
 package io.quarkus.ts.startstop.utils;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jboss.logging.Logger;
 
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
-import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -69,7 +69,7 @@ public class WebpageTester {
                 scanner.useDelimiter("\\A");
                 webPage = scanner.hasNext() ? scanner.next() : "";
             } catch (Exception e) {
-                LOGGER.fine("Waiting `" + stringToLookFor + "' to appear on " + url);
+                LOGGER.debug("Waiting `" + stringToLookFor + "' to appear on " + url);
             }
             if (webPage.contains(stringToLookFor)) {
                 found = true;

--- a/testsuite/src/main/resources/log4j2.xml
+++ b/testsuite/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight{%-5p}{FATAL=red blink, ERROR=red, WARN=yellow bold, INFO=green, DEBUG=green bold, TRACE=blue} [%style{%C{1.}}{cyan}] (%style{%M}{magenta}) %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
jboss-logging with log4j2, colorized console log

Fixes https://github.com/quarkus-qe/quarkus-startstop/issues/3

Example:
<img width="1377" alt="Screenshot 2020-04-28 at 09 31 58" src="https://user-images.githubusercontent.com/925259/80460093-a272ee80-8933-11ea-9c5e-9885cbd85ad9.png">
