### PR TITLE
Whitelist error_prone_annotations artifact

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -64,6 +64,7 @@ public enum WhitelistLogLines {
             Pattern.compile(".*errorprone.*"),
             // When GraalVM 19.3.1 is used; unrelated to the test
             Pattern.compile(".*forcing TieredStopAtLevel to full optimization because JVMCI is enabled.*"),
+            Pattern.compile(".*error_prone_annotations.*"),
     });
 
     public final Pattern[] errs;


### PR DESCRIPTION
Whitelist error_prone_annotations artifact

this artifacts causes false positive failure on `Pattern.compile("(?i:.*(ERROR|WARN).*)");` check

```
[ERROR]   CodeQuarkusTest.notsupportedExtensionsSubset:143->testRuntime:109 MVNW_DEV log should not contain error or warning lines that are not whitelisted. See testsuite/target/archived-logs/io.quarkus.ts.startstop.CodeQuarkusTest/notsupportedExtensionsSubset/dev-run.log and check these offending lines:
Progress (5): guava-27.0.1-jre.jar (1.8/2.7 MB) | jackson-databind-2.10.2.jar (1.1/1.4 MB) | netty-codec-http2-4.1.45.Final.jar (459 kB) | wildfly-elytron-password-impl-1.11.2.Final.jar (98 kB) | error_prone_annotations-2.2.0.jar (12/14 kB)
```