### PR TITLE
Acceptance jobs fixes

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
@@ -178,13 +178,13 @@ public class ArtifactGeneratorBOMTest {
     }
 
     @Test
-    @Tag("community")
+    @Tag("product-and-community")
     public void quarkusBomExtensionsA(TestInfo testInfo) throws Exception {
         testRuntime(testInfo, supportedExtensionsSubsetSetA, EnumSet.of(TestFlags.QUARKUS_BOM));
     }
 
     @Test
-    @Tag("community")
+    @Tag("product-and-community")
     public void quarkusBomExtensionsB(TestInfo testInfo) throws Exception {
         testRuntime(testInfo, supportedExtensionsSubsetSetB, EnumSet.of(TestFlags.QUARKUS_BOM));
     }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -188,7 +188,7 @@ public class ArtifactGeneratorTest {
             confAppPropsForSkeleton(appDir.getAbsolutePath());
 
             // Run
-            LOGGER.info("Running...");
+            LOGGER.info("Running... " + runCmd);
             runLogA = new File(logsDir + File.separator + (flags.contains(TestFlags.WARM_UP) ? "warmup-dev-run.log" : "dev-run.log"));
             pA = runCommand(runCmd, appDir, runLogA);
             appendln(whatIDidReport, appDir.getAbsolutePath());

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -239,8 +239,10 @@ public class Commands {
             generatorCmd.add("-DplatformVersion=" + getQuarkusPlatformVersion());
         } else if (flags.contains(TestFlags.QUARKUS_BOM)) {
             generatorCmd.add("-DplatformArtifactId=quarkus-bom");
+            generatorCmd.add("-DplatformVersion=" + getQuarkusVersion());
         } else if (flags.contains(TestFlags.UNIVERSE_BOM)) {
             generatorCmd.add("-DplatformArtifactId=quarkus-universe-bom");
+            generatorCmd.add("-DplatformVersion=" + getQuarkusVersion());
         } else if (flags.contains(TestFlags.UNIVERSE_PRODUCT_BOM)) {
             generatorCmd.add("-DplatformArtifactId=quarkus-universe-bom");
             generatorCmd.add("-DplatformGroupId=com.redhat.quarkus");
@@ -260,6 +262,7 @@ public class Commands {
             generatorCmd.add("/C");
         }
         generatorCmd.addAll(Arrays.asList(baseCommand));
+        generatorCmd.add("-DplatformVersion=" + getQuarkusVersion());
         generatorCmd.add("-Dextensions=" + String.join(",", extensions));
         generatorCmd.add("-Dmaven.repo.local=" + getLocalMavenRepoDir());
 

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
@@ -19,6 +19,7 @@
  */
 package io.quarkus.ts.startstop.utils;
 
+import static io.quarkus.ts.startstop.utils.Commands.getLocalMavenRepoDir;
 import static io.quarkus.ts.startstop.utils.Commands.getQuarkusVersion;
 
 /**
@@ -32,7 +33,7 @@ public enum MvnCmds {
             new String[]{"java", "-jar", "target/quarkus-runner.jar"}
     }),
     DEV(new String[][]{
-            new String[]{"mvn", "clean", "quarkus:dev"}
+            new String[]{"mvn", "clean", "quarkus:dev", "-Dmaven.repo.local=" + getLocalMavenRepoDir()}
     }),
     NATIVE(new String[][]{
             new String[]{"mvn", "clean", "compile", "quarkus:native-image", "-Pnative"},


### PR DESCRIPTION
 - Specify concrete Quarkus version for generated application and use proper local repo
 - Quarkus bom is available for both community and product

Reasoning:
mvn io.quarkus:quarkus-maven-plugin:1.3.3.Final-redhat-00003:create ... doesn't create project with 1.3.3.Final-redhat-00003 version of Quarkus
but the latest community version of quarkus ...
so atm it's 1.5.0 which reports that reflection stuff in dev mode
1.4.2 was reporting it just in regular build

I have to update tests, we can specify -DplatformVersion=1.3.3.Final-redhat-00003 to use prod version and not the latest community one