### PR TITLE
Ignore Jandex warning for generator test

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -65,6 +65,7 @@ public enum WhitelistLogLines {
             // When GraalVM 19.3.1 is used; unrelated to the test
             Pattern.compile(".*forcing TieredStopAtLevel to full optimization because JVMCI is enabled.*"),
             Pattern.compile(".*error_prone_annotations.*"),
+            Pattern.compile(".*Unable to properly register the hierarchy of the following classes for reflection as they are not in the Jandex index.*"),
     });
 
     public final Pattern[] errs;


### PR DESCRIPTION
Ignore Jandex warning for generator test.

Fixes https://github.com/quarkus-qe/quarkus-startstop/issues/19

Dev mode now exposes Jandex warning which was visible just during build.
This change happens starting with Quarkus 1.5.0.Final.