### PR TITLE
Drop provided org.eclipse.microprofile dependency

### DIFF
--- a/app-full-microprofile/pom.xml
+++ b/app-full-microprofile/pom.xml
@@ -21,13 +21,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.microprofile</groupId>
-            <artifactId>microprofile</artifactId>
-            <version>${microprofile.version}</version>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-auth-jwt</artifactId>
             <version>${vertx.auth.jwt.version}</version>

--- a/app-jax-rs-minimal/pom.xml
+++ b/app-jax-rs-minimal/pom.xml
@@ -21,13 +21,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.microprofile</groupId>
-            <artifactId>microprofile</artifactId>
-            <version>${microprofile.version}</version>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
             <version>${quarkus.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
     <properties>
         <quarkus.version>1.3.1.Final</quarkus.version>
         <vertx.auth.jwt.version>3.8.1</vertx.auth.jwt.version>
-        <microprofile.version>3.2</microprofile.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.version>3.8.1</maven.compiler.version>


### PR DESCRIPTION
Drop provided org.eclipse.microprofile dependency

This is not relevant way for Quarkus and it pulls in weird dependencies like `javax.inject:javax.inject:jar:1.0.0.redhat-6` in case of prod bits