### PR TITLE
Metrics are not collected for private methods starting with Quarkus 1.5

### DIFF
--- a/app-full-microprofile/src/main/java/com/example/quarkus/metric/MetricController.java
+++ b/app-full-microprofile/src/main/java/com/example/quarkus/metric/MetricController.java
@@ -48,7 +48,7 @@ public class MetricController {
     }
 
     @Gauge(name = "counter_gauge", unit = MetricUnits.NONE)
-    private long getCustomerCount() {
+    long getCustomerCount() {
         return counter.getCount();
     }
 }


### PR DESCRIPTION
Metrics are not collected for private methods starting with Quarkus 1.5

Users get following warning:
`[WARNING] [io.quarkus.smallrye.metrics.deployment.SmallRyeMetricsProcessor] Private method is annotated with a metric: long getCustomerCount() in class com.example.quarkus.metric.MetricController. Metrics are not collected for private methods. To enable metrics for this method, make it at least package-private.`
