### PR TITLE
Append properties starting with quarkus.native to the native image build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ spaces, diacritics, etc.
 
 Add ```-Dcode.quarkus.url=``` to test against a selected Code Quarkus site.
 
+## Parameters for NATIVE mode
+Properties starting with `quarkus.native` get appended to the command for the native image build.
+This allows customization of the native image build procedure as described in https://quarkus.io/guides/building-native-image#configuration-reference guide.
+
+Example command:
+```bash
+mvn clean verify -Ptestsuite -Dtest=SpecialCharsTest#diacriticsNative \
+    -Dquarkus.version=1.6.0.Final -Dquarkus.platform.version=1.6.0.Final \
+    -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=docker\
+    -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:20.1.0-java11
+```
+
 ## Values
 
  * App - the test app used

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -96,6 +96,18 @@ public class Commands {
         return System.getProperty("user.home") + File.separator + ".m2" + File.separator + "repository";
     }
 
+    /**
+     * Get system properties starting with `quarkus.native` prefix, for example quarkus.native.builder-image
+     * @return List of `-Dquarkus.native.xyz=foo` strings
+     */
+    public static List<String> getQuarkusNativeProperties() {
+        List<String> quarkusNativeProperties = System.getProperties().entrySet().stream()
+                .filter(e -> e.getKey().toString().contains("quarkus.native"))
+                .map(e -> "-D" + e.getKey() + "=" + e.getValue())
+                .collect(Collectors.toList());
+        return quarkusNativeProperties;
+    }
+
     public static String getQuarkusPlatformVersion() {
         for (String p : new String[]{"QUARKUS_PLATFORM_VERSION", "quarkus.platform.version"}) {
             String env = System.getenv().get(p);

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
@@ -19,6 +19,9 @@
  */
 package io.quarkus.ts.startstop.utils;
 
+import java.util.stream.Stream;
+
+import static io.quarkus.ts.startstop.utils.Commands.getQuarkusNativeProperties;
 import static io.quarkus.ts.startstop.utils.Commands.getLocalMavenRepoDir;
 import static io.quarkus.ts.startstop.utils.Commands.getQuarkusVersion;
 
@@ -36,7 +39,8 @@ public enum MvnCmds {
             new String[]{"mvn", "clean", "quarkus:dev", "-Dmaven.repo.local=" + getLocalMavenRepoDir()}
     }),
     NATIVE(new String[][]{
-            new String[]{"mvn", "clean", "compile", "package", "-Pnative"},
+            Stream.concat(Stream.of("mvn", "clean", "compile", "package", "-Pnative"),
+                    getQuarkusNativeProperties().stream()).toArray(String[]::new),
             new String[]{Commands.isThisWindows ? "target\\quarkus-runner" : "./target/quarkus-runner"}
     }),
     GENERATOR(new String[][]{


### PR DESCRIPTION
Append properties starting with `quarkus.native` to the native image build command

For details see addition to README.md in this PR