### PR TITLE
Quarkus 1.6 properly registers classes for reflection, whitelist is not needed

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -69,7 +69,6 @@ public enum WhitelistLogLines {
             // When GraalVM 19.3.1 is used; unrelated to the test
             Pattern.compile(".*forcing TieredStopAtLevel to full optimization because JVMCI is enabled.*"),
             Pattern.compile(".*error_prone_annotations.*"),
-            Pattern.compile(".*Unable to properly register the hierarchy of the following classes for reflection as they are not in the Jandex index.*"),
     });
 
     public final Pattern[] errs;


### PR DESCRIPTION
Quarkus 1.6 properly registers classes for reflection, whitelist is not needed
Details in https://github.com/quarkusio/quarkus/issues/9954

Whitelist was needed for Quarkus 1.5