### PR TITLE
Ports TestSecureController.java to Vert.x JWT 3.9.2 and Quarkus 1.7.0…

### DIFF
--- a/app-full-microprofile/src/main/java/com/example/quarkus/secure/TestSecureController.java
+++ b/app-full-microprofile/src/main/java/com/example/quarkus/secure/TestSecureController.java
@@ -1,10 +1,9 @@
 package com.example.quarkus.secure;
 
-import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.JWTOptions;
 import io.vertx.ext.auth.PubSecKeyOptions;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
-import io.vertx.ext.jwt.JWTOptions;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -62,7 +61,7 @@ public class TestSecureController {
         token.addAdditionalClaims("custom-value", "Jessie specific value");
         token.setGroups(Arrays.asList("user", "protected"));
 
-        return provider.generateToken(new JsonObject().mergeIn(token.toJSONString()), new JWTOptions().setAlgorithm("RS256"));
+        return provider.generateToken(new io.vertx.core.json.JsonObject().mergeIn(token.toJSONString()), new JWTOptions().setAlgorithm("RS256"));
     }
 
     private static String readPemFile() {

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     <name>Quarkus StartStop TS: Parent</name>
 
     <properties>
-        <quarkus.version>1.3.1.Final</quarkus.version>
-        <vertx.auth.jwt.version>3.8.1</vertx.auth.jwt.version>
+        <quarkus.version>1.7.0.Final</quarkus.version>
+        <vertx.auth.jwt.version>3.9.2</vertx.auth.jwt.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.version>3.8.1</maven.compiler.version>


### PR DESCRIPTION
….Final

Hello, this patch ports [TestSecureController.java](./app-full-microprofile/src/main/java/com/example/quarkus/secure/TestSecureController.java)
to Vert.x JWT auth 3.9.2 and Quarkus 1.7.0.Final. Without it, Quarkus 1.7.0.Final won't work
with this example. I run the testsuite locally with:

`mvn clean verify -Ptestsuite-community-no-native`

And it passed `io.quarkus.ts.startstop.StartStopTest/fullMicroProfileJVM/` just fine. The failures below are related to bumping the Quarkus version to 1.7.0.Final
and this patch does not concern those.

Cheers

K.

```
[ERROR] Failures:
[ERROR]   ArtifactGeneratorBOMTest.quarkusBomExtensionsB:189->testRuntime:145 Timeout 20s was reached. Empty webpage does not contain string: `Congratulations' ==> expected: <true> but was: <false>
[ERROR]   ArtifactGeneratorBOMTest.quarkusUniverseBomExtensionsB:213->testRuntime:145 Timeout 20s was reached. Empty webpage does not contain string: `Congratulations' ==> expected: <true> but was: <false>
[ERROR]   ArtifactGeneratorTest.manyExtensionsSetB:282->testRuntime:199 Timeout 1200s was reached. Empty webpage does not contain string: `Congratulations' ==> expected: <true> but was: <false>
[ERROR] Errors:
[ERROR]   CodeQuarkusTest.supportedExtensionsSubsetC:133->testRuntime:90 » IO Server ret...
[INFO]
[ERROR] Tests run: 24, Failures: 3, Errors: 1, Skipped: 0
```