### PR TITLE
Move to Quarkus 1.7 - first step

### DIFF
--- a/app-full-microprofile/pom.xml
+++ b/app-full-microprofile/pom.xml
@@ -28,7 +28,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-auth-jwt</artifactId>
-            <version>${vertx.auth.jwt.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,7 @@
     <name>Quarkus StartStop TS: Parent</name>
 
     <properties>
-        <quarkus.version>1.3.1.Final</quarkus.version>
-        <vertx.auth.jwt.version>3.8.1</vertx.auth.jwt.version>
+        <quarkus.version>1.7.0.Final</quarkus.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.version>3.8.1</maven.compiler.version>


### PR DESCRIPTION
Move to Quarkus 1.7 - first step

Replacement for https://github.com/quarkus-qe/quarkus-startstop/pull/29

There are test failures that need to be resolved, probably issues on Quarkus side.