### PR TITLE
Enhance checkLog() method to check against black listed line patterns

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
@@ -70,7 +70,7 @@ public class Logs {
     private static final Pattern startedPatternControlSymbols = Pattern.compile(".* started in .*188m([0-9\\.]+).*", Pattern.DOTALL);
     private static final Pattern stoppedPatternControlSymbols = Pattern.compile(".* stopped in .*188m([0-9\\.]+).*", Pattern.DOTALL);
 
-    private static final Pattern warnErrorDetectionPattern = Pattern.compile("(?i:.*(ERROR|WARN).*)");
+    private static final Pattern warnErrorDetectionPattern = Pattern.compile("(?i:.*(ERROR|WARN|SLF4J).*)");
 
     public static final long SKIP = -1L;
 


### PR DESCRIPTION
Enhance checkLog() method to check not only against Erorrs and Warnings, but also against undesirable patterns that lower user experience with Quarkus.
Cover for [jira-quarkus-101](https://issues.redhat.com/browse/QUARKUS-101?jql=project%20%3D%20QUARKUS%20AND%20labels%20%3D%20no-qe-coverage%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC)