### PR TITLE
Back-port to 1.7: Enhance checkLog(), repositories and pluginRepositories removal

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -41,6 +41,7 @@ import static io.quarkus.ts.startstop.utils.Commands.getArtifactGeneBaseDir;
 import static io.quarkus.ts.startstop.utils.Commands.getBuildCommand;
 import static io.quarkus.ts.startstop.utils.Commands.parsePort;
 import static io.quarkus.ts.startstop.utils.Commands.processStopper;
+import static io.quarkus.ts.startstop.utils.Commands.removeRepositoriesAndPluginRepositories;
 import static io.quarkus.ts.startstop.utils.Commands.runCommand;
 import static io.quarkus.ts.startstop.utils.Commands.unzip;
 import static io.quarkus.ts.startstop.utils.Commands.waitForTcpClosed;
@@ -90,6 +91,8 @@ public class CodeQuarkusTest {
             appendln(whatIDidReport, "Download URL: " + download(extensions, zipFile));
             LOGGER.info("Unzipping...");
             unzipLog = unzip(zipFile, GEN_BASE_DIR);
+            LOGGER.info("Removing repositories and pluginRepositories from pom.xml ...");
+            removeRepositoriesAndPluginRepositories(appDir + File.separator + "pom.xml");
             runLogA = new File(logsDir + File.separator + "dev-run.log");
             LOGGER.info("Running command: " + devCmd + " in directory: " + appDir);
             appendln(whatIDidReport, "Extensions: " + extensions.toString());

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -22,10 +22,17 @@ package io.quarkus.ts.startstop.utils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -318,6 +325,23 @@ public class Commands {
         Process p = pb.start();
         p.waitFor(3, TimeUnit.MINUTES);
         return unzipLog;
+    }
+
+    public static void removeRepositoriesAndPluginRepositories(String pomFilePath) throws Exception {
+        File pomFile = new File(pomFilePath);
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(pomFile);
+        NodeList repositories = doc.getElementsByTagName("repositories");
+        if (repositories.getLength() == 1) {
+            Node node = repositories.item(0);
+            node.getParentNode().removeChild(node);
+        }
+        NodeList pluginRepositories = doc.getElementsByTagName("pluginRepositories");
+        if (pluginRepositories.getLength() == 1) {
+            Node node = pluginRepositories.item(0);
+            node.getParentNode().removeChild(node);
+        }
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.transform(new DOMSource(doc), new StreamResult(pomFile));
     }
 
     public static boolean waitForTcpClosed(String host, int port, long loopTimeoutS) throws InterruptedException, UnknownHostException {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
@@ -70,7 +70,7 @@ public class Logs {
     private static final Pattern startedPatternControlSymbols = Pattern.compile(".* started in .*188m([0-9\\.]+).*", Pattern.DOTALL);
     private static final Pattern stoppedPatternControlSymbols = Pattern.compile(".* stopped in .*188m([0-9\\.]+).*", Pattern.DOTALL);
 
-    private static final Pattern warnErrorDetectionPattern = Pattern.compile("(?i:.*(ERROR|WARN).*)");
+    private static final Pattern warnErrorDetectionPattern = Pattern.compile("(?i:.*(ERROR|WARN|SLF4J).*)");
 
     public static final long SKIP = -1L;
 


### PR DESCRIPTION
Back-port to 1.7:
 - Enhance checkLog() method to check against black listed line patterns
 - Removing repositories and pluginRepositories from pom.xml 