### PR TITLE
Use quarkus.log.console.color=false to prevent escape characters in log messages for Windows

### DIFF
--- a/app-full-microprofile/src/main/resources/application.properties
+++ b/app-full-microprofile/src/main/resources/application.properties
@@ -4,6 +4,7 @@ value=lookup value
 com.example.quarkus.client.Service/mp-rest/url=http://localhost:8080/data/client/service
 
 quarkus.ssl.native=true
+quarkus.log.console.color=false
 
 mp.jwt.verify.publickey.location=META-INF/resources/publicKey.pem
 mp.jwt.verify.issuer=https://server.example.com

--- a/app-generated-skeleton/application.properties
+++ b/app-generated-skeleton/application.properties
@@ -12,3 +12,4 @@ quarkus.datasource.jdbc.driver=org.postgresql.Driver
 quarkus.datasource.username=quarkus_test
 quarkus.datasource.password=quarkus_test
 quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.log.console.color=false

--- a/app-jax-rs-minimal/src/main/resources/application.properties
+++ b/app-jax-rs-minimal/src/main/resources/application.properties
@@ -3,4 +3,4 @@ value=lookup value
 
 quarkus.ssl.native=true
 
-
+quarkus.log.console.color=false


### PR DESCRIPTION
Use quarkus.log.console.color=false to prevent escape characters in log messages for Windows

Example: ![Screenshot 2021-01-27 14 15 54](https://user-images.githubusercontent.com/925259/106005327-6a602e00-60b4-11eb-8b9c-c99f9f1e6679.png)

This probably happens just if the Windows instance has enabled color support for `cmd`
https://github.com/quarkusio/quarkus/issues/1029#issuecomment-532383501