### PR TITLE
Remove build-code-start from 1.11 branch, code.quarkus is always on the latest Quarkus version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,34 +66,3 @@ jobs:
           with:
             name: ci-artifacts
             path: artifacts-released-native${{ matrix.java }}.zip
-  build-code-start:
-    name: Code Quarkus build - released Quarkus
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ 11 ]
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
-        with:
-          java-version: ${{ matrix.java }}
-      - name: Build with Maven
-        run: |
-          mvn -V -B -s .github/mvn-settings.xml clean verify -Ptestsuite -DincludeTags=codequarkus
-      - name: Zip Artifacts
-        if: failure()
-        run: |
-          zip -r artifacts-jvm${{ matrix.java }}.zip . -i '*-reports/*' '*/archived-logs/*'
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: ci-artifacts
-          path: artifacts-code-start${{ matrix.java }}.zip


### PR DESCRIPTION
Remove build-code-start from 1.11 branch, code.quarkus is always on the latest Quarkus version