### PR TITLE
Increase the threshold from 50 ms to 60 ms for the first OK request

### DIFF
--- a/app-full-microprofile/threshold.properties
+++ b/app-full-microprofile/threshold.properties
@@ -1,6 +1,6 @@
 linux.jvm.time.to.first.ok.request.threshold.ms=2600
 linux.jvm.RSS.threshold.kB=550000
-linux.native.time.to.first.ok.request.threshold.ms=50
+linux.native.time.to.first.ok.request.threshold.ms=60
 linux.native.RSS.threshold.kB=120000
 windows.jvm.time.to.first.ok.request.threshold.ms=2500
 windows.jvm.RSS.threshold.kB=4000


### PR DESCRIPTION
Increase the threshold from 50 ms to 60 ms for the first OK request

GitHub CI sometimes reports numbers slightly above 50 ms limit
We are working on solution which could help us to follow the trends.