### PR TITLE
Quarkus 1.13

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
@@ -58,7 +58,7 @@ public enum CodeQuarkusExtensions {
     QUARKUS_SMALLRYE_JWT("quarkus-smallrye-jwt", "SmallRye JWT", "D9x", true),
     QUARKUS_SMALLRYE_OPENAPI("quarkus-smallrye-openapi", "SmallRye OpenAPI", "ARC", true),
     QUARKUS_UNDERTOW("quarkus-undertow", "Undertow Servlet", "LMC", true),
-    QUARKUS_UNDERTOW_WEBSOCKETS("quarkus-undertow-websockets", "Undertow WebSockets", "barD", true),
+    QUARKUS_WEBSOCKETS("websockets", "WebSockets", "JPE", true),
     QUARKUS_WEBJARS_LOCATOR("quarkus-webjars-locator", "WebJar Locator", "XSP", false),
     QUARKUS_GRPC("quarkus-grpc", "gRPC", "iDg", true),
     QUARKUS_HIBERNATE_ORM("quarkus-hibernate-orm", "Hibernate ORM", "vH0", true),

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -73,6 +73,10 @@ public enum WhitelistLogLines {
             Pattern.compile(".*This application uses the MP Metrics API. The micrometer extension currently provides a compatibility layer that supports the MP Metrics API, but metric names and recorded values will be different. Note that the MP Metrics compatibility layer will move to a different extension in the future.*"),
             // kubernetes-client tries to configure client from service account
             Pattern.compile(".*Error reading service account token from.*"),
+            // hibernate-orm issues this warning when default datasource is ambiguous
+            // (no explicit configuration, none or multiple JDBC driver extensions)
+            // Result of DevServices support https://github.com/quarkusio/quarkus/pull/14960
+            Pattern.compile(".*Unable to determine a database type for default datasource.*"),
     });
 
     public final Pattern[] errs;


### PR DESCRIPTION
- `undertow-websockets` extension renamed to `websockets`. https://github.com/quarkusio/quarkus/pull/15068
- New whitelist entry for datasource. https://github.com/quarkusio/quarkus/pull/14960