### PR TITLE
Enhance test for code.quarkus.redhat.com site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <commons.lang.version>3.9</commons.lang.version>
         <jboss-logging.version>3.4.1.Final</jboss-logging.version>
         <log4j.version>2.13.2</log4j.version>
+        <htmlunit.version>2.46.0</htmlunit.version>
 
         <!-- Test to be executed by default (should be all of them) -->
         <includeTags>generator,startstop,bomtests,codequarkus,special-chars</includeTags>
@@ -64,6 +65,11 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <version>${htmlunit.version}</version>
         </dependency>
     </dependencies>
 

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -1,12 +1,31 @@
 package io.quarkus.ts.startstop;
 
+import com.gargoylesoftware.htmlunit.BrowserVersion;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
+import com.gargoylesoftware.htmlunit.html.HtmlImage;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.javascript.background.JavaScriptJobManager;
 import io.quarkus.ts.startstop.utils.Commands;
-import io.quarkus.ts.startstop.utils.WebpageTester;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestInfo;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 /**
@@ -20,30 +39,100 @@ public class CodeQuarkusSiteTest {
     private static final Logger LOGGER = Logger.getLogger(CodeQuarkusSiteTest.class.getName());
 
     public static final String webPageUrl = Commands.getCodeQuarkusURL("https://code.quarkus.redhat.com/");
-    public static final String elementIcon = "<link rel=\"shortcut icon\" type=\"image/png\" href=\"https://www.redhat.com/misc/favicon.ico\">";
-    public static final String elementTitle = "<title>Quarkus - Start coding with code.quarkus.redhat.com</title>";
+    public static final String elementTitleByText = "Quarkus - Start coding with code.quarkus.redhat.com";
+    public static final String elementIconByXpath = "//link[@rel=\"shortcut icon\"][@href=\"https://www.redhat.com/misc/favicon.ico\"]";
+    public static final String elementRedHatLogoByXpath= "//img[@class=\"logo\"][@alt=\"Red Hat Logo\"]";
+    public static final String elementSupportedFlagByXpath = "//a[@class=\"extension-tag supported\"]";
+    public static final String elementQuarkusPlatformVersionByXpath = "normalize-space(//div[@class=\"quarkus-version\"]/span/text()[last()])";
 
-    public void testRuntime(TestInfo testInfo, String searchElement) throws Exception {
+    private WebClient webClient;
 
-        try {
-            long timeoutS = 1 * 60;
-            LOGGER.info("Timeout: " + timeoutS + "s. Waiting for the web to load...");
-            long totalTimeMillis = WebpageTester.testWeb(webPageUrl, timeoutS, searchElement, true);
-            LOGGER.info("Element has been found! Total time: " + totalTimeMillis);
-            assertTrue(timeoutS * 1000 > totalTimeMillis);
-        } finally {
-            LOGGER.info("Test is finished!");
-        }
+    @BeforeEach
+    public void init(){
+        webClient = new WebClient(BrowserVersion.CHROME);
+        webClient.getOptions().setThrowExceptionOnScriptError(false);
+        webClient.getOptions().setJavaScriptEnabled(true);
+        java.util.logging.Logger.getLogger("com.gargoylesoftware").setLevel(Level.OFF);
+    }
+
+    @AfterEach
+    public void close(){
+        webClient.close();
     }
 
 
     @Test
     public void validatePresenceOfIcon(TestInfo testInfo) throws Exception {
-        testRuntime(testInfo, elementIcon);
+        final HtmlPage page = loadPage(webPageUrl, 60);
+        LOGGER.info("Trying to find element: " + elementIconByXpath);
+        HtmlElement shortcutIcon = page.getFirstByXPath(elementIconByXpath);
+        assertNotNull(shortcutIcon, "Element: " + elementIconByXpath + " is missing!");
     }
 
     @Test
     public void validatePresenceOfTitle(TestInfo testInfo) throws Exception {
-        testRuntime(testInfo, elementTitle);
+        final HtmlPage page = loadPage(webPageUrl, 60);
+        LOGGER.info("Verify page title is: " + elementTitleByText);
+        assertEquals(page.getTitleText(), elementTitleByText,
+                "Title doesn't match. Found on the web: " + page.getTitleText() + ". Expected: " + elementTitleByText);
+    }
+
+    @Test
+    public void validatePresenceOfRedHatLogo(TestInfo testInfo) throws Exception {
+        final HtmlPage page = loadPage(webPageUrl, 60);
+        LOGGER.info("Trying to find element: " + elementRedHatLogoByXpath);
+        HtmlImage redHatLogo = page.getFirstByXPath(elementRedHatLogoByXpath);
+        assertNotNull(redHatLogo, "Element: " + elementRedHatLogoByXpath + " is missing!");
+    }
+
+    @Test
+    public void validatePresenceOfSupportedFlags(TestInfo testInfo) throws Exception {
+        final HtmlPage page = loadPage(webPageUrl, 60);
+        LOGGER.info("Trying to find element: " + elementSupportedFlagByXpath);
+        List<HtmlElement> supportedExtensions = page.getByXPath(elementSupportedFlagByXpath);
+        assertNotNull(supportedExtensions, "Element: " + elementSupportedFlagByXpath + " is missing!");
+    }
+
+    @Test
+    public void validateQuarkusVersionMatch(TestInfo testInfo) throws Exception{
+        String quarkusPlatformVersion = "";
+        if(System.getProperty("maven.repo.local") == null){
+            LOGGER.warn("System property 'maven.repo.local' is not specified. Skip test execution.");
+            return;
+        }
+        Path quarkusProductBomPath = Paths.get(System.getProperty("maven.repo.local")).resolve("com/redhat/quarkus/quarkus-product-bom");
+        try (Stream<Path> paths = Files.walk(quarkusProductBomPath)) {
+            List<Path> folders = paths.filter(Files::isDirectory).collect(Collectors.toList());
+            quarkusPlatformVersion = folders.get(1).getFileName().toString();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        final HtmlPage page = loadPage(webPageUrl, 60);
+        LOGGER.info("Trying to find element: " + elementQuarkusPlatformVersionByXpath);
+        String quarkusPlatformVersionFromWeb = page.getFirstByXPath(elementQuarkusPlatformVersionByXpath);
+
+        assertNotNull(quarkusPlatformVersionFromWeb, "Element: " + elementQuarkusPlatformVersionByXpath + " is missing!");
+        assertEquals(quarkusPlatformVersion, quarkusPlatformVersionFromWeb,
+                "Quarkus versions doesn't match. Found on the web: " + quarkusPlatformVersionFromWeb + ". Expected: " + quarkusPlatformVersion);
+    }
+
+
+    public HtmlPage loadPage(String url, int timeoutSeconds) throws InterruptedException {
+        HtmlPage page = null;
+        long startTime = System.currentTimeMillis();
+        long endTime = startTime + timeoutSeconds * 1000;
+        LOGGER.info("Loading web page " + url);
+        try {
+            page = webClient.getPage(url);
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot load the page" + webPageUrl);
+        }
+        JavaScriptJobManager manager = page.getEnclosingWindow().getJobManager();
+        while (manager.getJobCount() > 0 && System.currentTimeMillis() < endTime) {
+            Thread.sleep(1000);
+        }
+
+        return page;
     }
 }


### PR DESCRIPTION
Enhance testcase according to https://github.com/quarkus-qe/quarkus-test-plans/blob/main/QUARKUS-821.md

Library HtmlUnit was used because the previous loading page solution doesn't wait for JavaScript to finish to fully load the page.

Logs were off, because HtmlUnit library is very strict to any mistake in CSS or javascript, which is okay for the browser, but not for HtmlUnit. Therefore a lot of logs were printed.