### PR TITLE
Upgrade to 1.13.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <name>Quarkus StartStop TS: Parent</name>
 
     <properties>
-        <quarkus.version>1.12.1.Final</quarkus.version>
+        <quarkus.version>1.13.2.Final</quarkus.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.version>3.8.1</maven.compiler.version>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -107,13 +107,12 @@ public class ArtifactGeneratorTest {
             "resteasy-jsonb",
             "scheduler",
             "spring-boot-properties",
-            "smallrye-reactive-messaging-amqp",
+            "smallrye-reactive-streams-operators",
             "spring-data-jpa",
             "spring-di",
             "spring-security",
             "spring-web",
             "undertow",
-            "undertow-websockets",
             "vertx",
             "vertx-web",
             "grpc",
@@ -150,8 +149,8 @@ public class ArtifactGeneratorTest {
             "smallrye-openapi",
             "smallrye-opentracing",
             "smallrye-reactive-messaging",
+            "smallrye-reactive-messaging-amqp",
             "smallrye-reactive-messaging-kafka",
-            "smallrye-reactive-streams-operators",
             "spring-data-jpa",
             "spring-data-rest",
             "spring-di",
@@ -160,7 +159,7 @@ public class ArtifactGeneratorTest {
             "spring-cloud-config-client",
             "spring-scheduled",
             "spring-cache",
-
+            "websockets",
     };
 
     public void testRuntime(TestInfo testInfo, String[] extensions, Set<TestFlags> flags) throws Exception {


### PR DESCRIPTION
- Rename undertow-websockets to websockets
- The "smallrye-reactive-streams-operators" is not compatible with other reactive implementations: https://github.com/quarkusio/quarkus/issues/9754