### PR TITLE
Maven 3.8.1 rise a warning msg that makes some test fail

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -51,10 +51,12 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.version}</version>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.version}</version>
                 <configuration>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -77,6 +77,8 @@ public enum WhitelistLogLines {
             // (no explicit configuration, none or multiple JDBC driver extensions)
             // Result of DevServices support https://github.com/quarkusio/quarkus/pull/14960
             Pattern.compile(".*Unable to determine a database type for default datasource.*"),
+            // Maven 3.8.1 throw a warn msg related to a mirror default configuration
+            Pattern.compile(".*org.apache.maven.settings.io.SettingsParseException: Unrecognised tag: 'blocked'.*"),
     }),
     // Quarkus is not being gratefully shutdown in Windows when running in Dev mode.
     // Reported by https://github.com/quarkusio/quarkus/issues/14647.


### PR DESCRIPTION
- Add the following warning msg `org.apache.maven.settings.io.SettingsParseException: Unrecognised tag: 'blocked'` to the list of messages to be ignored as errors. 