### PR TITLE
[1.11] Increase timeout for SpecialCharacters test cases

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/SpecialCharsTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/SpecialCharsTest.java
@@ -129,7 +129,7 @@ public class SpecialCharsTest {
 
             // Test web page
             LOGGER.info("Testing web page content...");
-            int timeout = mvnCmds != MvnCmds.DEV ? 5 : 60;
+            int timeout = mvnCmds != MvnCmds.DEV ? 30 : 120;
             for (String[] urlContent : app.urlContent.urlContent) {
                 WebpageTester.testWeb(urlContent[0], timeout, urlContent[1], false);
             }


### PR DESCRIPTION
This is needed for slow Windows instances where 5 sec is not enough