### PR TITLE
[1.11] Extend Quarkus live reload test

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ The goal of this test is to test Quarkus maven artifact generator, i.e. to to us
 empty (Hello World) skeleton and build it in Quarkus dev mode. The objective is to make sure all required
 extensions are correctly found.
 
-Next, the project is run in dev mode, time to the first O.K. request is measured, a ```.java``` file is changed and the time
-it took to get the expected results after hot reload is measured.
+Next, the project is run in dev mode, time to the first O.K. request is measured. Then, an existing ```.java``` file
+is changed and a new one is added, which causes hot reload. After that, a request to the modified file is issued,
+and the time it took to get the expected results is measured. Also, separate request to the added file is issued
+to verify that the new resource has been loaded. Response time is not measured in this case.
 
 The whole run is executed as a warm-up to download the Internet and then again to measure the times.
 The properties for thresholds are stored in [app-generated-skeleton/threshold.properties](./app-generated-skeleton/threshold.properties).

--- a/app-generated-skeleton/AddedController.java
+++ b/app-generated-skeleton/AddedController.java
@@ -1,0 +1,14 @@
+package org.my.group;
+
+import javax.inject.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/hello-added")
+@Singleton
+public class AddedController {
+    @GET
+    public String sayHello() {
+        return "Hello added";
+    }
+}

--- a/app-generated-skeleton/README.md
+++ b/app-generated-skeleton/README.md
@@ -3,7 +3,12 @@ This is a placeholder directory to keep
 
 It also keeps dummy [application.properties](./application.properties) used for the
 generated skeleton purely to satisfy some extensions' expected non-empty directives.
-No functional code is actually run for the skeleton though. It merely checks the generator and Hello World in dev mode.
+
+Another resource that kept here is an [AddedController](./AddedController.java) class,
+which is used to test live reload of added classes.
+
+Apart from that, no functional code is actually run for the skeleton though.
+It merely checks the generator and Hello World in dev mode.
 
 When executed, the test actually uses ```ARTIFACT_GENERATOR_WORKSPACE``` directory
 to generate the ```app-generated-skeleton``` project into. If neither sys prop nor env prop ```ARTIFACT_GENERATOR_WORKSPACE```

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -391,10 +391,15 @@ public class Commands {
     // TODO we should get rid of it once Quarkus progresses with walid config per extension in generated examples
     public static void confAppPropsForSkeleton(String appDir) throws IOException {
         // Config, see app-generated-skeleton/README.md
-        String appPropsSrc = BASE_DIR + File.separator + Apps.GENERATED_SKELETON.dir + File.separator + "application.properties";
-        String appPropsDst = appDir + File.separator + "src" + File.separator + "main" + File.separator + "resources" + File.separator + "application.properties";
-        Files.copy(Paths.get(appPropsSrc),
-                Paths.get(appPropsDst), StandardCopyOption.REPLACE_EXISTING);
+        final String appRelativePath =
+                "src" + File.separator + "main" + File.separator + "resources" + File.separator + "application.properties";
+        copyFileForSkeleton("application.properties", Paths.get(appDir + File.separator + appRelativePath));
+    }
+
+    public static void copyFileForSkeleton(String skeletonFileRelativePath, Path destPath)
+            throws IOException {
+        final String srcPath = BASE_DIR + File.separator + Apps.GENERATED_SKELETON.dir + File.separator + skeletonFileRelativePath;
+        Files.copy(Paths.get(srcPath), destPath, StandardCopyOption.REPLACE_EXISTING);
     }
 
     public static void adjustPrettyPrintForJsonLogging(String appDir) throws IOException {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/URLContent.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/URLContent.java
@@ -44,7 +44,8 @@ public enum URLContent {
     }),
     GENERATED_SKELETON(new String[][]{
             new String[]{"http://localhost:8080", "Congratulations"},
-            new String[]{"http://localhost:8080/hello-spring", "Bye Spring"}
+            new String[]{"http://localhost:8080/hello-spring", "Bye Spring"},
+            new String[]{"http://localhost:8080/hello-added", "Hello added"}
     });
 
     public final String[][] urlContent;


### PR DESCRIPTION
Backport of https://github.com/quarkus-qe/quarkus-startstop/pull/85.
Depends on https://github.com/quarkus-qe/quarkus-startstop/pull/86.

---

In reload test, in addition to modifying an existing class,
add a new class and verify that it has been loaded.

Covers https://issues.redhat.com/browse/QUARKUS-1020.