### PR TITLE
Draft: Move to Quarkus 2.0 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,13 @@ Results in:
 [INFO] 
 ```
 
+## Debugging
+To debug particular test in IDEA, open Maven tab, select module and lifecycle phase e.x. (module: testsuite, phase: verify),
+right click to create a new configuration. Parameters Tab -> Command line, specify full Maven command you are using 
+to run the test and add `-DforkCount=0`  
+Example: `verify -Ptestsuite -Dtest=CodeQuarkusTest#supportedExtensionsSubsetC -DforkCount=0 -f pom.xml`  
+Set the breakpoint where needed and click on green bug symbol on top bar of IDEA (make sure a new configuration is selected).
+
 ## Troubleshooting
 To help to troubleshoot the issues, some performance insights from the application are needed.
 One of the best way to gather performance insights is to generate CPU and allocation FlameGraphs using Async Profiler.

--- a/app-full-microprofile/src/main/java/com/example/quarkus/secure/TestSecureController.java
+++ b/app-full-microprofile/src/main/java/com/example/quarkus/secure/TestSecureController.java
@@ -17,10 +17,10 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.JWTOptions;
 import io.vertx.ext.auth.PubSecKeyOptions;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
-import io.vertx.ext.jwt.JWTOptions;
 
 @Path("/secured")
 @ApplicationScoped
@@ -49,7 +49,7 @@ public class TestSecureController {
         JWTAuth provider = JWTAuth.create(null, new JWTAuthOptions()
                 .addPubSecKey(new PubSecKeyOptions()
                         .setAlgorithm("RS256")
-                        .setSecretKey(key)));
+                        .setBuffer(key))); // Set up private key
 
         MPJWTToken token = new MPJWTToken();
         token.setAud("targetService");
@@ -72,10 +72,8 @@ public class TestSecureController {
                         TestSecureController.class.getResourceAsStream("/privateKey.pem"), StandardCharsets.US_ASCII))) {
             String line;
             while ((line = is.readLine()) != null) {
-                if (!line.startsWith("-")) {
-                    sb.append(line);
-                    sb.append('\n');
-                }
+                sb.append(line);
+                sb.append('\n');
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/app-full-microprofile/src/main/resources/application.properties
+++ b/app-full-microprofile/src/main/resources/application.properties
@@ -10,9 +10,9 @@ mp.jwt.verify.publickey.location=META-INF/resources/publicKey.pem
 mp.jwt.verify.issuer=https://server.example.com
 quarkus.smallrye-jwt.enabled=true
 
-quarkus.jaeger.service-name=Demo-Service-A
-quarkus.jaeger.sampler-type=const
-quarkus.jaeger.sampler-param=1
-quarkus.jaeger.endpoint=http://localhost:14268/api/traces
+#quarkus.jaeger.service-name=Demo-Service-A //TODO Watch https://github.com/quarkusio/quarkus/issues/18131
+#quarkus.jaeger.sampler-type=const
+#quarkus.jaeger.sampler-param=1
+#quarkus.jaeger.endpoint=http://localhost:14268/api/traces
 
 quarkus.native.additional-build-args=-H:Log=registerResource:, -H:IncludeResources=privateKey.pem

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>1.13.3.Final</quarkus.version>
+        <quarkus.version>2.0.2.Final</quarkus.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.version>3.8.1</maven.compiler.version>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -84,12 +84,13 @@ public class CodeQuarkusTest {
     public static final List<List<CodeQuarkusExtensions>> mixedEx = CodeQuarkusExtensions.partition(1, CodeQuarkusExtensions.Flag.MIXED);
     
     public static final Stream<CodeQuarkusExtensions> supportedExWithCodeStarter() {
-        return Arrays.asList(CodeQuarkusExtensions.QUARKUS_CONFIG_YAML,
-                CodeQuarkusExtensions.QUARKUS_LOGGING_JSON,
+        return Arrays.asList(
+                //CodeQuarkusExtensions.QUARKUS_CONFIG_YAML,
+                CodeQuarkusExtensions.QUARKUS_QUTE, // This is TECH-PREVIEW
+                CodeQuarkusExtensions.QUARKUS_WEBSOCKETS,
                 CodeQuarkusExtensions.QUARKUS_RESTEASY,
                 CodeQuarkusExtensions.QUARKUS_RESTEASY_JACKSON,
-                CodeQuarkusExtensions.QUARKUS_SPRING_WEB,
-                CodeQuarkusExtensions.QUARKUS_QUTE).stream();
+                CodeQuarkusExtensions.QUARKUS_SPRING_WEB).stream();
     }
 
     public void testRuntime(TestInfo testInfo, List<CodeQuarkusExtensions> extensions, MvnCmds mvnCmds) throws Exception {
@@ -159,7 +160,7 @@ public class CodeQuarkusTest {
             pA = runCommand(cmd, appDir, runLogA);
             
             // It takes time to download the Internet
-            long timeoutS = 10 * 60;
+            long timeoutS = 1 * 60;
             LOGGER.info("Timeout: " + timeoutS + "s. Waiting for the web content...");
             WebpageTester.testWeb(skeletonApp.urlContent[0][0], timeoutS, skeletonApp.urlContent[0][1], false);
             LOGGER.info("Terminating and scanning logs...");
@@ -200,7 +201,9 @@ public class CodeQuarkusTest {
 
     @Test
     public void supportedExtensionsSubsetC(TestInfo testInfo) throws Exception {
-        testRuntime(testInfo, supportedEx.get(2), MvnCmds.MVNW_DEV);
+        List<CodeQuarkusExtensions> supportedExtensionsSubsetC = supportedEx.get(2);
+        supportedExtensionsSubsetC.add(CodeQuarkusExtensions.QUARKUS_RESTEASY);
+        testRuntime(testInfo, supportedExtensionsSubsetC, MvnCmds.MVNW_DEV);
     }
 
     @Test

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/URLContent.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/URLContent.java
@@ -35,11 +35,11 @@ public enum URLContent {
             new String[]{"http://localhost:8080/data/config/injected", "Config value as Injected by CDI Injected value"},
             new String[]{"http://localhost:8080/data/config/lookup", "Config value from ConfigProvider lookup value"},
             new String[]{"http://localhost:8080/data/resilience", "Fallback answer due to timeout"},
-            new String[]{"http://localhost:8080/health", "\"UP\""},
+            new String[]{"http://localhost:8080/q/health", "\"UP\""},
             new String[]{"http://localhost:8080/data/metric/timed", "Request is used in statistics, check with the Metrics call."},
-            new String[]{"http://localhost:8080/metrics", "ontroller_timed_request_seconds_count"},
+            new String[]{"http://localhost:8080/q/metrics", "Controller_timed_request_seconds_count"},
             new String[]{"http://localhost:8080/data/secured/test", "Jessie specific value"},
-            new String[]{"http://localhost:8080/openapi", "/resilience"},
+            new String[]{"http://localhost:8080/q/openapi", "/resilience"},
             new String[]{"http://localhost:8080/data/client/test/parameterValue=xxx", "Processed parameter value 'parameterValue=xxx'"}
     }),
     GENERATED_SKELETON(new String[][]{

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -40,6 +40,7 @@ public enum WhitelistLogLines {
             Pattern.compile(".*TestSecureController.java.*"),
             // Well, the RestClient demo probably should do some cleanup before shutdown...?
             Pattern.compile(".*Closing a class org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient.*"),
+            Pattern.compile(".*Class does not exist in ClassLoader QuarkusClassLoader.*"), // TODO remove when resolved https://github.com/quarkusio/quarkus/issues/18746
     }),
     GENERATED_SKELETON(new Pattern[]{
             // It so happens that the dummy skeleton tries to find Mongo. This is expected.
@@ -79,6 +80,8 @@ public enum WhitelistLogLines {
             Pattern.compile(".*Unable to determine a database type for default datasource.*"),
             // Maven 3.8.1 throw a warn msg related to a mirror default configuration
             Pattern.compile(".*org.apache.maven.settings.io.SettingsParseException: Unrecognised tag: 'blocked'.*"),
+            Pattern.compile(".*io.qua.arc.impl.*"), // TODO remove when resolved https://github.com/quarkusio/quarkus/issues/18105
+            Pattern.compile(".*Class does not exist in ClassLoader QuarkusClassLoader.*"), // TODO remove when resolved https://github.com/quarkusio/quarkus/issues/18746
     }),
     // Quarkus is not being gratefully shutdown in Windows when running in Dev mode.
     // Reported by https://github.com/quarkusio/quarkus/issues/14647.


### PR DESCRIPTION
Resolved:
1. Redirects to `/q` are not happening. Need to specify full path
2. TestSecureController: 
-- Replace deprecated method
-- Add first and the last line of PEM file to Buffer (required by libraries)
3. Jaeger config props disabled because of https://github.com/quarkusio/quarkus/issues/18131 

TODO: 
1. test with 2.0.0.Final and universe-bom
2. watch https://github.com/quarkusio/quarkus/issues/18105 (fails due to not whitelisted lines, can be suppressed in test suite)