### PR TITLE
Fix JVM build, dedicated job for format validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,27 @@ on:
   schedule:
     - cron: '0 23 * * *'
 jobs:
+  linux-validate-format:
+    name: Linux - Validate format
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11 ]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Install JDK {{ matrix.java }}
+        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Build with Maven
+        run: |
+          mvn -V -B -s .github/mvn-settings.xml validate -Pide,validate-format
   linux-build-released-jvm:
     name: Linux - JVM build - released Quarkus
     runs-on: ubuntu-latest
@@ -24,7 +45,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build with Maven
         run: |
-          mvn -V -B -s .github/mvn-settings.xml clean verify -DexcludeTags=product,native,codequarkus -Dvalidate-format
+          mvn -V -B -s .github/mvn-settings.xml clean verify -DexcludeTags=product,native,codequarkus
       - name: Zip Artifacts
         if: failure()
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,8 @@
                                 <exclude>**/target/**/*.xml</exclude>
                                 <!-- Exclude Quarkus main repository -->
                                 <exclude>**/quarkus/**/*.xml</exclude>
+                                <!-- Exclude .idea -->
+                                <exclude>.idea/**</exclude>
                             </excludes>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Fix JVM build, dedicated job for format validation

Before this fix the JVM run was not doing a lot, just checking the root pom.xml