### PR TITLE
Move to new Quarkus platform without universe BOM

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
@@ -21,7 +21,6 @@ package io.quarkus.ts.startstop;
 
 import io.quarkus.ts.startstop.utils.Apps;
 import io.quarkus.ts.startstop.utils.Commands;
-import io.quarkus.ts.startstop.utils.FakeOIDCServer;
 import io.quarkus.ts.startstop.utils.MvnCmds;
 import io.quarkus.ts.startstop.utils.TestFlags;
 import io.quarkus.ts.startstop.utils.URLContent;
@@ -95,8 +94,6 @@ public class ArtifactGeneratorBOMTest {
 
         URLContent skeletonApp = Apps.GENERATED_SKELETON.urlContent;
 
-        FakeOIDCServer fakeOIDCServer = new FakeOIDCServer(6661, "localhost");
-
         try {
             // Cleanup
             cleanDirOrFile(appDir.getAbsolutePath(), logsDir);
@@ -160,8 +157,6 @@ public class ArtifactGeneratorBOMTest {
 
             checkJarSuffixes(flags, appDir);
         } finally {
-            fakeOIDCServer.stop();
-
             // Make sure processes are down even if there was an exception / failure
             if (pA != null) {
                 processStopper(pA, true);
@@ -203,27 +198,4 @@ public class ArtifactGeneratorBOMTest {
         testRuntime(testInfo, supportedExtensionsSubsetSetB, EnumSet.of(TestFlags.PRODUCT_BOM));
     }
 
-    @Test
-    @Tag("community")
-    public void quarkusUniverseBomExtensionsA(TestInfo testInfo) throws Exception {
-        testRuntime(testInfo, supportedExtensionsSubsetSetA, EnumSet.of(TestFlags.UNIVERSE_BOM));
-    }
-
-    @Test
-    @Tag("community")
-    public void quarkusUniverseBomExtensionsB(TestInfo testInfo) throws Exception {
-        testRuntime(testInfo, supportedExtensionsSubsetSetB, EnumSet.of(TestFlags.UNIVERSE_BOM));
-    }
-
-    @Test
-    @Tag("product")
-    public void quarkusUniverseProductBomExtensionsA(TestInfo testInfo) throws Exception {
-        testRuntime(testInfo, supportedExtensionsSubsetSetA, EnumSet.of(TestFlags.UNIVERSE_PRODUCT_BOM));
-    }
-
-    @Test
-    @Tag("product")
-    public void quarkusUniverseProductBomExtensionsB(TestInfo testInfo) throws Exception {
-        testRuntime(testInfo, supportedExtensionsSubsetSetB, EnumSet.of(TestFlags.UNIVERSE_PRODUCT_BOM));
-    }
 }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -64,7 +64,6 @@ import org.junit.jupiter.api.TestInfo;
 
 import io.quarkus.ts.startstop.utils.Apps;
 import io.quarkus.ts.startstop.utils.Commands;
-import io.quarkus.ts.startstop.utils.FakeOIDCServer;
 import io.quarkus.ts.startstop.utils.LogBuilder;
 import io.quarkus.ts.startstop.utils.Logs;
 import io.quarkus.ts.startstop.utils.MvnCmds;
@@ -118,7 +117,8 @@ public class ArtifactGeneratorTest {
             "vertx",
             "vertx-web",
             "grpc",
-            "infinispan-client",
+//             TODO https://github.com/quarkusio/quarkus/issues/19081
+//            "infinispan-client",
             "cache",
             "micrometer",
             "quarkus-openshift-client",
@@ -183,7 +183,6 @@ public class ArtifactGeneratorTest {
         } else {
             LOGGER.info(mn + ": Testing setup: " + String.join(" ", generatorCmd));
         }
-        FakeOIDCServer fakeOIDCServer = new FakeOIDCServer(6661, "localhost");
 
         try {
             // Cleanup
@@ -290,7 +289,6 @@ public class ArtifactGeneratorTest {
             appendln(whatIDidReport, log.headerMarkdown + "\n" + log.lineMarkdown);
             checkThreshold(Apps.GENERATED_SKELETON, MvnCmds.GENERATOR, SKIP, timeToFirstOKRequest, timeToReloadedOKRequest);
         } finally {
-            fakeOIDCServer.stop();
             // Make sure processes are down even if there was an exception / failure
             if (pA != null) {
                 processStopper(pA, true);

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -284,13 +284,6 @@ public class Commands {
         } else if (flags.contains(TestFlags.QUARKUS_BOM)) {
             generatorCmd.add("-DplatformArtifactId=quarkus-bom");
             generatorCmd.add("-DplatformVersion=" + getQuarkusVersion());
-        } else if (flags.contains(TestFlags.UNIVERSE_BOM)) {
-            generatorCmd.add("-DplatformArtifactId=quarkus-universe-bom");
-            generatorCmd.add("-DplatformVersion=" + getQuarkusVersion());
-        } else if (flags.contains(TestFlags.UNIVERSE_PRODUCT_BOM)) {
-            generatorCmd.add("-DplatformArtifactId=quarkus-universe-bom");
-            generatorCmd.add("-DplatformGroupId=com.redhat.quarkus");
-            generatorCmd.add("-DplatformVersion=" + getQuarkusPlatformVersion());
         }
         generatorCmd.add("-Dextensions=" + String.join(",", extensions));
         generatorCmd.add("-Dmaven.repo.local=" + repoDir);
@@ -306,6 +299,7 @@ public class Commands {
             generatorCmd.add("/C");
         }
         generatorCmd.addAll(Arrays.asList(baseCommand));
+        generatorCmd.add("-DplatformArtifactId=quarkus-bom"); // https://github.com/quarkusio/quarkus/issues/19083
         generatorCmd.add("-DplatformVersion=" + getQuarkusVersion());
         generatorCmd.add("-Dextensions=" + String.join(",", extensions));
         generatorCmd.add("-Dmaven.repo.local=" + getLocalMavenRepoDir());

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
@@ -148,7 +148,7 @@ public class Logs {
     }
 
     public static void checkJarSuffixes(Set<TestFlags> flags, File appDir) throws IOException {
-        if (flags.contains(TestFlags.PRODUCT_BOM) || flags.contains(TestFlags.UNIVERSE_PRODUCT_BOM)) {
+        if (flags.contains(TestFlags.PRODUCT_BOM)) {
             List<Path> possiblyUnwantedArtifacts = Logs.listJarsFailingNameCheck(
                     appDir.getAbsolutePath() + File.separator + "target" + File.separator + "lib");
             List<String> reportArtifacts = new ArrayList<>();

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/TestFlags.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/TestFlags.java
@@ -27,9 +27,7 @@ package io.quarkus.ts.startstop.utils;
 public enum TestFlags {
     WARM_UP("This run is just a warm up for Dev mode."),
     QUARKUS_BOM("platformArtifactId will use quarkus-bom"),
-    PRODUCT_BOM("platformArtifactId will use quarkus-product-bom"),
-    UNIVERSE_BOM("platformArtifactId will use quarkus-universe-bom"),
-    UNIVERSE_PRODUCT_BOM("platformArtifactId will use quarkus-universe-bom, and -DplatformGroupId=com.redhat.quarkus");
+    PRODUCT_BOM("platformArtifactId will use quarkus-product-bom");
     public final String label;
 
     TestFlags(String label) {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -88,6 +88,7 @@ public enum WhitelistLogLines {
             Pattern.compile(".*org.apache.maven.settings.io.SettingsParseException: Unrecognised tag: 'blocked'.*"),
             Pattern.compile(".*io.qua.arc.impl.*"), // TODO remove when resolved https://github.com/quarkusio/quarkus/issues/18105
             Pattern.compile(".*Class does not exist in ClassLoader QuarkusClassLoader.*"), // TODO remove when resolved https://github.com/quarkusio/quarkus/issues/18746
+            Pattern.compile(".*Detected a split package usage which is considered a bad practice and should be avoided.*"), // TODO remove when resolved https://github.com/quarkusio/quarkus/issues/19092
     }),
     // Quarkus is not being gratefully shutdown in Windows when running in Dev mode.
     // Reported by https://github.com/quarkusio/quarkus/issues/14647.


### PR DESCRIPTION
Move to new Quarkus platform without universe BOM

Also dropping usage of FakeOIDCServer as the OIDC extension doesn't need running Keycloak/RHSSO server when not used.