### PR TITLE
JavaDoc and license related updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,24 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    Copyright (c) 2020 Contributors to the Quarkus StartStop Project
-
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    You may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.quarkus.ts.startstop</groupId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -1,24 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    Copyright (c) 2020 Contributors to the Quarkus StartStop Project
-
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    You may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
@@ -65,8 +65,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * BOM tests for quarkus-maven-plugin generator, command defines BOM via platformArtifactId property
- *
- * @author Michal Karm Babacek <karm@redhat.com>
  */
 @Tag("bomtests")
 public class ArtifactGeneratorBOMTest {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop;
 
 import io.quarkus.ts.startstop.utils.Apps;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop;
 
 import static io.quarkus.ts.startstop.utils.Commands.adjustPrettyPrintForJsonLogging;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -73,8 +73,6 @@ import io.quarkus.ts.startstop.utils.WebpageTester;
 
 /**
  * Tests for quarkus-maven-plugin generator
- *
- * @author Michal Karm Babacek <karm@redhat.com>
  */
 @Tag("generator")
 public class ArtifactGeneratorTest {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -30,8 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Tests for checking presence of element on webpage
- *
- * @author Shpak Kyrylo <kshpak@redhat.com>
  */
 @Tag("codequarkus")
 public class CodeQuarkusSiteTest {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop;
 
 import io.quarkus.ts.startstop.utils.Apps;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -70,8 +70,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for code.quarkus.io generator
- *
- * @author Michal Karm Babacek <karm@redhat.com>
  */
 @Tag("codequarkus")
 public class CodeQuarkusTest {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/NativeDebugTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/NativeDebugTest.java
@@ -30,8 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests Quarkus native mode with "-Dquarkus.native.debug.enabled=true"
  * Verify that debug symbols are created as well as the source cache
- *
- * @author Kyrylo Shpak <kshpak@redhat.com>
  */
 @Tag("native")
 public class NativeDebugTest {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/SpecialCharsTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/SpecialCharsTest.java
@@ -42,8 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for running Quarkus applications on path with special characters
- *
- * @author Ondrej Machala <omachala@redhat.com>
  */
 @Tag("special-chars")
 public class SpecialCharsTest {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop;
 
 import io.quarkus.ts.startstop.utils.Apps;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
@@ -70,8 +70,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests for build and start of applications with some real source code
  * Detains in https://github.com/quarkus-qe/quarkus-startstop#startstoptest
- *
- * @author Michal Karm Babacek <karm@redhat.com>
  */
 @Tag("startstop")
 public class StartStopTest {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Apps.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Apps.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop.utils;
 
 import org.apache.commons.lang3.StringUtils;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Apps.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Apps.java
@@ -32,11 +32,6 @@ import java.util.Properties;
 import static io.quarkus.ts.startstop.StartStopTest.BASE_DIR;
 import static org.junit.jupiter.api.Assertions.fail;
 
-/**
- * Maven commands.
- *
- * @author Michal Karm Babacek <karm@redhat.com>
- */
 public enum Apps {
     JAX_RS_MINIMAL("app-jax-rs-minimal", URLContent.JAX_RS_MINIMAL, WhitelistLogLines.JAX_RS_MINIMAL),
     FULL_MICROPROFILE("app-full-microprofile", URLContent.FULL_MICROPROFILE, WhitelistLogLines.FULL_MICROPROFILE),

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
@@ -24,9 +24,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-/**
- * @author Michal Karm Babacek <karm@redhat.com>
- */
 public enum CodeQuarkusExtensions {
 
     QUARKUS_RESTEASY("quarkus-resteasy", "RESTEasy JAX-RS", "98e", true),

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop.utils;
 
 import java.util.ArrayList;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop.utils;
 
 import static io.quarkus.ts.startstop.StartStopTest.BASE_DIR;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -75,9 +75,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-/**
- * @author Michal Karm Babacek <karm@redhat.com>
- */
 public class Commands {
     private static final Logger LOGGER = Logger.getLogger(Commands.class.getName());
 

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/FakeOIDCServer.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/FakeOIDCServer.java
@@ -31,9 +31,6 @@ import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-/**
- * @author Michal Karm Babacek <karm@redhat.com>
- */
 public class FakeOIDCServer implements Runnable {
     private static final Logger LOGGER = Logger.getLogger(FakeOIDCServer.class.getName());
     private final ServerSocket server;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/FakeOIDCServer.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/FakeOIDCServer.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop.utils;
 
 import org.jboss.logging.Logger;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/LogBuilder.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/LogBuilder.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop.utils;
 
 import java.util.Objects;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/LogBuilder.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/LogBuilder.java
@@ -21,9 +21,6 @@ package io.quarkus.ts.startstop.utils;
 
 import java.util.Objects;
 
-/**
- * @author Michal Karm Babacek <karm@redhat.com>
- */
 public class LogBuilder {
 
     public static class Log {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop.utils;
 
 import org.apache.commons.lang3.StringUtils;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
@@ -47,9 +47,6 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * @author Michal Karm Babacek <karm@redhat.com>
- */
 public class Logs {
     private static final Logger LOGGER = Logger.getLogger(Logs.class.getName());
 

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop.utils;
 
 import java.util.stream.Stream;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
@@ -26,9 +26,7 @@ import static io.quarkus.ts.startstop.utils.Commands.getLocalMavenRepoDir;
 import static io.quarkus.ts.startstop.utils.Commands.getQuarkusVersion;
 
 /**
- * Maven commands.
- *
- * @author Michal Karm Babacek <karm@redhat.com>
+ * Maven commands
  */
 public enum MvnCmds {
     JVM(new String[][]{

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/TestFlags.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/TestFlags.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop.utils;
 
 /**

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/TestFlags.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/TestFlags.java
@@ -21,8 +21,6 @@ package io.quarkus.ts.startstop.utils;
 
 /**
  * Some flags to drive the tests flow
- *
- * @author Michal Karm Babacek <karm@redhat.com>
  */
 public enum TestFlags {
     WARM_UP("This run is just a warm up for Dev mode."),

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/URLContent.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/URLContent.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop.utils;
 
 /**

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/URLContent.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/URLContent.java
@@ -21,8 +21,6 @@ package io.quarkus.ts.startstop.utils;
 
 /**
  * Available endpoitns and expected content.
- *
- * @author Michal Karm Babacek <karm@redhat.com>
  */
 public enum URLContent {
     JAX_RS_MINIMAL(new String[][]{

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WebpageTester.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WebpageTester.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop.utils;
 
 import org.apache.commons.lang3.StringUtils;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WebpageTester.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WebpageTester.java
@@ -30,9 +30,6 @@ import java.util.Scanner;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * @author Michal Karm Babacek <karm@redhat.com>
- */
 public class WebpageTester {
     private static final Logger LOGGER = Logger.getLogger(WebpageTester.class.getName());
 

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -23,8 +23,6 @@ import java.util.regex.Pattern;
 
 /**
  * Whitelists errors in log files.
- *
- * @author Michal Karm Babacek <karm@redhat.com>
  */
 public enum WhitelistLogLines {
     JAX_RS_MINIMAL(new Pattern[]{

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop.utils;
 
 import java.util.regex.Pattern;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
@@ -1,22 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
 package io.quarkus.ts.startstop.utils;
 
 /**

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
@@ -23,8 +23,6 @@ package io.quarkus.ts.startstop.utils;
  * Whitelists jar names.
  *
  * There are basically known issues. The enum should be empty.
- *
- * @author Michal Karm Babacek <karm@redhat.com>
  */
 public enum WhitelistProductBomJars {
     PRODUCT_BOM(new String[]{

--- a/testsuite/src/it/resources/JSONtoEnum.java
+++ b/testsuite/src/it/resources/JSONtoEnum.java
@@ -26,9 +26,6 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * @author Michal Karm Babacek <karm@redhat.com>
- */
 public class JSONtoEnum {
     public static Pattern pattern = Pattern.compile("(?i).*\"id\":\"[^:]*:([^\"]*)\".*\"shortId\":\"([^\"]*)\".*\"name\":\"([^\"]*)\".*\"tags\":\\[([^]]*)].*");
 

--- a/testsuite/src/it/resources/JSONtoEnum.java
+++ b/testsuite/src/it/resources/JSONtoEnum.java
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2020 Contributors to the Quarkus StartStop project
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Scanner;


### PR DESCRIPTION
Drop `@author` flag as git / https://github.com/quarkus-qe/quarkus-startstop/graphs/contributors give better overview

Drop Copyright from the files, root of the repo contains LICENSE file 