### PR TITLE
Slight increase of timeout for Windows

### DIFF
--- a/app-generated-skeleton/threshold.properties
+++ b/app-generated-skeleton/threshold.properties
@@ -1,5 +1,5 @@
 # With all extensions enabled, it could take the dev mode a long time to start.
 linux.generated.dev.time.to.first.ok.request.threshold.ms=50000
 linux.generated.dev.time.to.reload.threshold.ms=20000
-windows.generated.dev.time.to.first.ok.request.threshold.ms=50000
+windows.generated.dev.time.to.first.ok.request.threshold.ms=55000
 windows.generated.dev.time.to.reload.threshold.ms=20000


### PR DESCRIPTION
Slight increase of timeout for Windows

To help with fails like https://github.com/quarkus-qe/quarkus-startstop/runs/3225713623?check_suite_focus=true

follow up action in https://trello.com/c/e3MxfB6b/913-check-performance-111-vs-21