### PR TITLE
Disable devServices on dev mode

### DIFF
--- a/app-generated-skeleton/application.properties
+++ b/app-generated-skeleton/application.properties
@@ -21,3 +21,4 @@ quarkus.log.console.color=false
 quarkus.kafka.devservices.enabled=false
 quarkus.amqp.devservices.enabled=false
 quarkus.datasource.devservices=false
+quarkus.keycloak.devservices.enabled=false

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -403,7 +403,8 @@ public class Commands {
                 "quarkus.kafka.devservices.enabled=false\n" +
                 "quarkus.amqp.devservices.enabled=false\n" +
                 "quarkus.mongodb.devservices.enabled=false\n" +
-                "quarkus.redis.devservices.enabled=false\n"
+                "quarkus.redis.devservices.enabled=false\n" +
+                "quarkus.keycloak.devservices.enabled=false\n"
                 ;
 
         if (Files.exists(appProps)) {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -41,6 +41,7 @@ public enum WhitelistLogLines {
                     "quarkus.amqp.devservices.enabled|" +
                     "quarkus.mongodb.devservices.enabled|" +
                     "quarkus.redis.devservices.enabled|" +
+                    "quarkus.keycloak.devservices.enabled|" +
                     "quarkus.jaeger.enabled|" +
                     "quarkus.jaeger.service-name|" +
                     "quarkus.jaeger.sampler-param|" +


### PR DESCRIPTION
- DevService in dev mode is enabled by default, so could increase the started time and reload time adding noise to the final metrics 