### PR TITLE
[2.2] Bump Quarkus to 2.2.2.Final && Maintain Quarkus Ide Config independently

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>2.1.1.Final</quarkus.version>
-        <quarkus-ide-config.version>2.1.1.Final</quarkus-ide-config.version>
+        <quarkus.version>2.2.2.Final</quarkus.version>
+        <quarkus-ide-config.version>2.2.2.Final</quarkus-ide-config.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.version>3.8.1</maven.compiler.version>

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
         <quarkus.version>2.1.1.Final</quarkus.version>
+        <quarkus-ide-config.version>2.1.1.Final</quarkus-ide-config.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.version>3.8.1</maven.compiler.version>
@@ -135,7 +136,7 @@
                     <dependency>
                         <artifactId>quarkus-ide-config</artifactId>
                         <groupId>io.quarkus</groupId>
-                        <version>${quarkus.version}</version>
+                        <version>${quarkus-ide-config.version}</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
@@ -25,7 +25,7 @@ public enum MvnCmds {
     GENERATOR(new String[][]{
             new String[]{
                     "mvn",
-                    "io.quarkus:quarkus-maven-plugin:" + getQuarkusVersion() + ":create",
+                    "io.quarkus.platform:quarkus-maven-plugin:" + getQuarkusVersion() + ":create",
                     "-DprojectGroupId=my-groupId",
                     "-DprojectArtifactId=" + Apps.GENERATED_SKELETON.dir,
                     "-DprojectVersion=1.0.0-SNAPSHOT",


### PR DESCRIPTION
Backport of https://github.com/quarkus-qe/quarkus-startstop/pull/108