### PR TITLE
Fix quarkus maven plugin group ID ++ Disable Quarkus Registry Client to boost generator Maven commands

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -96,8 +96,8 @@ public class ArtifactGeneratorTest {
             "vertx",
             "vertx-web",
             "grpc",
-//             TODO https://github.com/quarkusio/quarkus/issues/19081
-//            "infinispan-client",
+            //             TODO https://github.com/quarkusio/quarkus/issues/19081
+            //            "infinispan-client",
             "cache",
             "micrometer",
             "quarkus-openshift-client",

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -63,6 +63,9 @@ public class Commands {
     private static final Pattern numPattern = Pattern.compile("[ \t]*[0-9]+[ \t]*");
     private static final Pattern quarkusVersionPattern = Pattern.compile("[ \t]*<quarkus.version>([^<]*)</quarkus.version>.*");
     private static final Pattern trailingSlash = Pattern.compile("/+$");
+    private static final String QUARKUS_PLATFORM_GROUP_ID = "com.redhat.quarkus.platform";
+    private static final String QUARKUS_UPSTREAM_GROUP_ID = "io.quarkus.platform";
+    private static final String REDHAT_VERSION_TAG = "-redhat-";
 
     public static String mvnw() {
         return Commands.isThisWindows ? "mvnw.cmd" : "./mvnw";
@@ -147,6 +150,14 @@ public class Commands {
             throw new IllegalArgumentException(failure);
         }
         throw new IllegalArgumentException(failure);
+    }
+
+    public static String getQuarkusGroupId() {
+        if (getQuarkusVersion().contains(REDHAT_VERSION_TAG)) {
+            return QUARKUS_PLATFORM_GROUP_ID;
+        }
+
+        return QUARKUS_UPSTREAM_GROUP_ID;
     }
 
     public static String getBaseDir() {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -267,8 +267,8 @@ public class Commands {
         }
         generatorCmd.addAll(Arrays.asList(baseCommand));
         if (flags.contains(TestFlags.PRODUCT_BOM)) {
-            generatorCmd.add("-DplatformArtifactId=quarkus-product-bom");
-            generatorCmd.add("-DplatformGroupId=com.redhat.quarkus");
+            generatorCmd.add("-DplatformArtifactId=quarkus-bom");
+            generatorCmd.add("-DplatformGroupId=com.redhat.quarkus.platform");
             generatorCmd.add("-DplatformVersion=" + getQuarkusPlatformVersion());
         } else if (flags.contains(TestFlags.QUARKUS_BOM)) {
             generatorCmd.add("-DplatformArtifactId=quarkus-bom");

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
@@ -128,7 +128,7 @@ public class Logs {
     public static void checkJarSuffixes(Set<TestFlags> flags, File appDir) throws IOException {
         if (flags.contains(TestFlags.PRODUCT_BOM)) {
             List<Path> possiblyUnwantedArtifacts = Logs.listJarsFailingNameCheck(
-                    appDir.getAbsolutePath() + File.separator + "target" + File.separator + "lib");
+                    appDir.getAbsolutePath() + File.separator + "target" + File.separator + "quarkus-app" + File.separator + "lib");
             List<String> reportArtifacts = new ArrayList<>();
             boolean containsNotWhitelisted = false;
             for (Path p : possiblyUnwantedArtifacts) {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
@@ -30,7 +30,8 @@ public enum MvnCmds {
                     "-DprojectGroupId=my-groupId",
                     "-DprojectArtifactId=" + Apps.GENERATED_SKELETON.dir,
                     "-DprojectVersion=1.0.0-SNAPSHOT",
-                    "-DpackageName=org.my.group"
+                    "-DpackageName=org.my.group",
+                    "-DquarkusRegistryClient=false"
             }
     }),
     MVNW_DEV(new String[][]{

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.startstop.utils;
 
 import java.util.stream.Stream;
 
+import static io.quarkus.ts.startstop.utils.Commands.getQuarkusGroupId;
 import static io.quarkus.ts.startstop.utils.Commands.getQuarkusNativeProperties;
 import static io.quarkus.ts.startstop.utils.Commands.getLocalMavenRepoDir;
 import static io.quarkus.ts.startstop.utils.Commands.getQuarkusVersion;
@@ -25,7 +26,7 @@ public enum MvnCmds {
     GENERATOR(new String[][]{
             new String[]{
                     "mvn",
-                    "io.quarkus.platform:quarkus-maven-plugin:" + getQuarkusVersion() + ":create",
+                    getQuarkusGroupId() + ":quarkus-maven-plugin:" + getQuarkusVersion() + ":create",
                     "-DprojectGroupId=my-groupId",
                     "-DprojectArtifactId=" + Apps.GENERATED_SKELETON.dir,
                     "-DprojectVersion=1.0.0-SNAPSHOT",

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/TestFlags.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/TestFlags.java
@@ -6,7 +6,7 @@ package io.quarkus.ts.startstop.utils;
 public enum TestFlags {
     WARM_UP("This run is just a warm up for Dev mode."),
     QUARKUS_BOM("platformArtifactId will use quarkus-bom"),
-    PRODUCT_BOM("platformArtifactId will use quarkus-product-bom");
+    PRODUCT_BOM("platformArtifactId will use quarkus-bom from Product");
     public final String label;
 
     TestFlags(String label) {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -62,7 +62,8 @@ public enum WhitelistLogLines {
             // Maven 3.8.1 throw a warn msg related to a mirror default configuration
             Pattern.compile(".*org.apache.maven.settings.io.SettingsParseException: Unrecognised tag: 'blocked'.*"),
             Pattern.compile(".*io.qua.arc.impl.*"), // TODO remove when resolved https://github.com/quarkusio/quarkus/issues/18105
-            Pattern.compile(".*Using @ConfigProperty for Quarkus configuration items is deprecated.*"), // TODO remove when resolved https://github.com/quarkusio/quarkus/issues/19242
+            // We have disabled the Quarkus Registry Client (-DquarkusRegistryClient=false)
+            Pattern.compile(".*The extension catalog will be narrowed to.*"),
     }),
     // Quarkus is not being gratefully shutdown in Windows when running in Dev mode.
     // Reported by https://github.com/quarkusio/quarkus/issues/14647.


### PR DESCRIPTION
Quarkus Maven Plugin should be com.redhat.quarkus.platform for RHBQ and io.quarkus.platform for Upstream. I'm not very proud of how I did it, but didn't see any easier way.

++ Disable Quarkus Registry Client to boost generator Maven commands