### PR TITLE
RESTEasy reactive based extensions sets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>2.2.2.Final</quarkus.version>
+        <quarkus.version>2.2.3.Final</quarkus.version>
         <quarkus-ide-config.version>2.2.2.Final</quarkus-ide-config.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
@@ -24,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 
 import static io.quarkus.ts.startstop.ArtifactGeneratorTest.supportedExtensionsSubsetSetA;
 import static io.quarkus.ts.startstop.ArtifactGeneratorTest.supportedExtensionsSubsetSetB;
+import static io.quarkus.ts.startstop.ArtifactGeneratorTest.supportedReactiveExtensionsSubsetSetA;
+import static io.quarkus.ts.startstop.ArtifactGeneratorTest.supportedReactiveExtensionsSubsetSetB;
 import static io.quarkus.ts.startstop.utils.Commands.adjustPrettyPrintForJsonLogging;
 import static io.quarkus.ts.startstop.utils.Commands.cleanDirOrFile;
 import static io.quarkus.ts.startstop.utils.Commands.confAppPropsForSkeleton;
@@ -175,6 +177,30 @@ public class ArtifactGeneratorBOMTest {
     @Tag("product")
     public void quarkusProductBomExtensionsB(TestInfo testInfo) throws Exception {
         testRuntime(testInfo, supportedExtensionsSubsetSetB, EnumSet.of(TestFlags.PRODUCT_BOM));
+    }
+
+    @Test
+    @Tag("product-and-community")
+    public void quarkusBomReactiveExtensionsA(TestInfo testInfo) throws Exception {
+        testRuntime(testInfo, supportedReactiveExtensionsSubsetSetA, EnumSet.of(TestFlags.QUARKUS_BOM));
+    }
+
+    @Test
+    @Tag("product-and-community")
+    public void quarkusBomReactiveExtensionsB(TestInfo testInfo) throws Exception {
+        testRuntime(testInfo, supportedReactiveExtensionsSubsetSetB, EnumSet.of(TestFlags.QUARKUS_BOM));
+    }
+
+    @Test
+    @Tag("product")
+    public void quarkusProductBomReactiveExtensionsA(TestInfo testInfo) throws Exception {
+        testRuntime(testInfo, supportedReactiveExtensionsSubsetSetA, EnumSet.of(TestFlags.PRODUCT_BOM));
+    }
+
+    @Test
+    @Tag("product")
+    public void quarkusProductBomReactiveExtensionsB(TestInfo testInfo) throws Exception {
+        testRuntime(testInfo, supportedReactiveExtensionsSubsetSetB, EnumSet.of(TestFlags.PRODUCT_BOM));
     }
 
 }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/TestFlags.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/TestFlags.java
@@ -5,6 +5,7 @@ package io.quarkus.ts.startstop.utils;
  */
 public enum TestFlags {
     WARM_UP("This run is just a warm up for Dev mode."),
+    RESTEASY_REACTIVE("Using RESTEasy Reactive extensions"),
     QUARKUS_BOM("platformArtifactId will use quarkus-bom"),
     PRODUCT_BOM("platformArtifactId will use quarkus-bom from Product");
     public final String label;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/URLContent.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/URLContent.java
@@ -24,7 +24,8 @@ public enum URLContent {
     GENERATED_SKELETON(new String[][]{
             new String[]{"http://localhost:8080", "Congratulations"},
             new String[]{"http://localhost:8080/greeting", "Bye Spring"},
-            new String[]{"http://localhost:8080/hello-added", "Hello added"}
+            new String[]{"http://localhost:8080/hello-added", "Hello added"},
+            new String[]{"http://localhost:8080/hello", "Bye RESTEasy Reactive"},
     });
 
     public final String[][] urlContent;


### PR DESCRIPTION
RESTEasy reactive based extensions sets.

Generator related tests for now.

Side note: With 2.2.3.ER1 I've seen few non productized RESTEasy reactive artifacts
```
lib/main/io.quarkus.resteasy.reactive.resteasy-reactive-client-2.2.3.Final.jar
lib/main/io.quarkus.resteasy.reactive.resteasy-reactive-vertx-2.2.3.Final.jar
lib/main/io.quarkus.resteasy.reactive.resteasy-reactive-common-2.2.3.Final.jar
```
Is it know / tracked in JIRA?