### PR TITLE
Ignore some trace messages in Windows

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -111,6 +111,9 @@ public enum WhitelistLogLines {
                         // The problem is that the method name contains "Error" and hence it became an offending line.
                         // For example: this is happening with using Mongo extension (without a Mongo instance).
                         Pattern.compile(".*translateErrorToIOException.*"),
+                        // In Windows, randomly prints traces like:
+                        // TRACE [io.qua.builder] (build-49) Starting step "io.quarkus.jaxb.deployment.JaxbProcessor..."
+                        Pattern.compile(".*Starting step.*"),
                 };
             case LINUX:
             	return new Pattern[] {


### PR DESCRIPTION
Example of failure in: https://github.com/quarkus-qe/quarkus-startstop/runs/3642297852?check_suite_focus=true
Caused by these traces:

```
TRACE [io.qua.builder] (build-49) Starting step "io.quarkus.jaxb.deployment.JaxbProcessor#ignoreWarnings"
```