### PR TITLE
Support Quarkus main in generator tests

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -273,6 +273,9 @@ public class Commands {
         } else if (flags.contains(TestFlags.QUARKUS_BOM)) {
             generatorCmd.add("-DplatformArtifactId=quarkus-bom");
             generatorCmd.add("-DplatformVersion=" + getQuarkusVersion());
+            if (getQuarkusVersion().equals("999-SNAPSHOT")) {
+                generatorCmd.add("-DplatformGroupId=io.quarkus");
+            }
         }
         generatorCmd.add("-Dextensions=" + String.join(",", extensions));
         generatorCmd.add("-Dmaven.repo.local=" + repoDir);
@@ -288,6 +291,9 @@ public class Commands {
             generatorCmd.add("/C");
         }
         generatorCmd.addAll(Arrays.asList(baseCommand));
+        if (getQuarkusVersion().equals("999-SNAPSHOT")) {
+            generatorCmd.add("-DplatformGroupId=io.quarkus");
+        }
         generatorCmd.add("-DplatformArtifactId=quarkus-bom"); // https://github.com/quarkusio/quarkus/issues/19083
         generatorCmd.add("-DplatformVersion=" + getQuarkusVersion());
         generatorCmd.add("-Dextensions=" + String.join(",", extensions));


### PR DESCRIPTION
Support Quarkus main in generator tests

There is known issue for Quarkus main - https://github.com/quarkusio/quarkus/issues/21033

But I hesitate to do any workarounds for it in the tests. That bug needs to be fixed and it's not affecting our CI as we use just the released versions.