### PR TITLE
Increase time.to.first.ok.request.threshold.ms for JAX-RS minimal app

### DIFF
--- a/app-jax-rs-minimal/threshold.properties
+++ b/app-jax-rs-minimal/threshold.properties
@@ -1,6 +1,6 @@
 linux.jvm.time.to.first.ok.request.threshold.ms=2000
 linux.jvm.RSS.threshold.kB=380000
-linux.native.time.to.first.ok.request.threshold.ms=35
+linux.native.time.to.first.ok.request.threshold.ms=45
 linux.native.RSS.threshold.kB=90000
 windows.jvm.time.to.first.ok.request.threshold.ms=4500
 windows.jvm.RSS.threshold.kB=4500


### PR DESCRIPTION
Increase time.to.first.ok.request.threshold.ms for JAX-RS minimal app

Issue reported in https://github.com/quarkusio/quarkus/issues/21149

Should help to get green results with CI for now, let's see if the time can get lowered with some updates in Quarkus.