### PR TITLE
Replace htmlunit with playwright

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <commons.lang.version>3.9</commons.lang.version>
         <jboss-logging.version>3.4.1.Final</jboss-logging.version>
         <log4j.version>2.13.2</log4j.version>
-        <htmlunit.version>2.46.0</htmlunit.version>
+        <playwright.version>1.17.0</playwright.version>
         <formatter-maven-plugin.version>2.15.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.6.0</impsort-maven-plugin.version>
         <xml-format-maven-plugin>3.1.2</xml-format-maven-plugin>
@@ -49,9 +49,9 @@
             <version>${log4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
-            <version>${htmlunit.version}</version>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+            <version>${playwright.version}</version>
         </dependency>
     </dependencies>
     <profiles>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -1,18 +1,20 @@
 package io.quarkus.ts.startstop;
 
-import com.gargoylesoftware.htmlunit.BrowserVersion;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlElement;
-import com.gargoylesoftware.htmlunit.html.HtmlImage;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.javascript.background.JavaScriptJobManager;
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.ElementState;
 import io.quarkus.ts.startstop.utils.Commands;
 import org.jboss.logging.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -20,7 +22,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -32,67 +33,71 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for checking presence of element on webpage
  */
 @Tag("codequarkus")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CodeQuarkusSiteTest {
 
     private static final Logger LOGGER = Logger.getLogger(CodeQuarkusSiteTest.class.getName());
 
+    public static final String pageLoadedSelector = ".quarkus-project-edition-form";
     public static final String webPageUrl = Commands.getCodeQuarkusURL("https://code.quarkus.redhat.com/");
     public static final String elementTitleByText = "Quarkus - Start coding with code.quarkus.redhat.com";
     public static final String elementIconByXpath = "//link[@rel=\"shortcut icon\"][@href=\"https://www.redhat.com/misc/favicon.ico\"]";
     public static final String elementRedHatLogoByXpath= "//img[@class=\"logo\"][@alt=\"Red Hat Logo\"]";
     public static final String elementSupportedFlagByXpath = "//div[@class=\"extension-tag supported dropdown-toggle\"]";
-    public static final String elementQuarkusPlatformVersionByXpath = "normalize-space(//div[@class=\"quarkus-stream final\"]/@title)";
+    public static final String elementQuarkusPlatformVersionByXpath = "//div[@class=\"quarkus-stream final\"]";
 
-    private WebClient webClient;
+    private BrowserContext browserContext; // Operates in incognito mode
 
-    @BeforeEach
+    @BeforeAll
     public void init(){
-        webClient = new WebClient(BrowserVersion.CHROME);
-        webClient.getOptions().setThrowExceptionOnScriptError(false);
-        webClient.getOptions().setJavaScriptEnabled(true);
-        java.util.logging.Logger.getLogger("com.gargoylesoftware").setLevel(Level.OFF);
+        Playwright playwright = Playwright.create();
+        Browser browser = playwright.chromium().launch(new BrowserType.LaunchOptions()
+                .setArgs(List.of("--headless", "--disable-gpu", "--no-sandbox")));
+        browserContext = browser.newContext();
+        LOGGER.info("Incognito browser session has been created");
     }
 
-    @AfterEach
+    @AfterAll
     public void close(){
-        webClient.close();
+        browserContext.close();
     }
 
 
     @Test
-    public void validatePresenceOfIcon(TestInfo testInfo) throws Exception {
-        final HtmlPage page = loadPage(webPageUrl, 60);
+    public void validatePresenceOfIcon(TestInfo testInfo) {
+        Page page = loadPage(webPageUrl, 60);
         LOGGER.info("Trying to find element: " + elementIconByXpath);
-        HtmlElement shortcutIcon = page.getFirstByXPath(elementIconByXpath);
-        assertNotNull(shortcutIcon, "Element: " + elementIconByXpath + " is missing!");
+        Locator icon = page.locator(elementIconByXpath);
+        assertEquals(1, icon.count(), "Element: " + elementIconByXpath + " is missing!");
     }
 
     @Test
-    public void validatePresenceOfTitle(TestInfo testInfo) throws Exception {
-        final HtmlPage page = loadPage(webPageUrl, 60);
+    public void validatePresenceOfTitle(TestInfo testInfo) {
+        Page page = loadPage(webPageUrl, 60);
         LOGGER.info("Verify page title is: " + elementTitleByText);
-        assertEquals(page.getTitleText(), elementTitleByText,
-                "Title doesn't match. Found on the web: " + page.getTitleText() + ". Expected: " + elementTitleByText);
+        assertEquals(elementTitleByText, page.title(),
+                "Title doesn't match. Found on the web: " + page.title() + ". Expected: " + elementTitleByText);
     }
 
     @Test
-    public void validatePresenceOfRedHatLogo(TestInfo testInfo) throws Exception {
-        final HtmlPage page = loadPage(webPageUrl, 60);
+    public void validatePresenceOfRedHatLogo(TestInfo testInfo) {
+        Page page = loadPage(webPageUrl, 60);
         LOGGER.info("Trying to find element: " + elementRedHatLogoByXpath);
-        HtmlImage redHatLogo = page.getFirstByXPath(elementRedHatLogoByXpath);
-        assertNotNull(redHatLogo, "Element: " + elementRedHatLogoByXpath + " is missing!");
+        Locator redHatLogo = page.locator(elementRedHatLogoByXpath);
+        redHatLogo.elementHandle().waitForElementState(ElementState.VISIBLE);
+        assertTrue(redHatLogo.isVisible(), "Element: " + elementRedHatLogoByXpath + " is missing or not visible!");
     }
 
     @Test
-    public void validatePresenceOfSupportedFlags(TestInfo testInfo) throws Exception {
-        final HtmlPage page = loadPage(webPageUrl, 60);
+    public void validatePresenceOfSupportedFlags(TestInfo testInfo) {
+        Page page = loadPage(webPageUrl, 60);
         LOGGER.info("Trying to find element: " + elementSupportedFlagByXpath);
-        List<HtmlElement> supportedExtensions = page.getByXPath(elementSupportedFlagByXpath);
-        assertTrue(supportedExtensions.size() > 1, "Element: " + elementSupportedFlagByXpath + " is missing!");
+        Locator supportedExtensions = page.locator(elementSupportedFlagByXpath);
+        assertTrue(supportedExtensions.count() > 1, "Element: " + elementSupportedFlagByXpath + " is missing!");
     }
 
     @Test
-    public void validateQuarkusVersionMatch(TestInfo testInfo) throws Exception{
+    public void validateQuarkusVersionMatch(TestInfo testInfo) {
         String quarkusPlatformVersion = "";
         if(System.getProperty("maven.repo.local") == null){
             LOGGER.warn("System property 'maven.repo.local' is not specified. Skip test execution.");
@@ -106,9 +111,9 @@ public class CodeQuarkusSiteTest {
             throw new UncheckedIOException(e);
         }
 
-        final HtmlPage page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, 60);
         LOGGER.info("Trying to find element: " + elementQuarkusPlatformVersionByXpath);
-        String quarkusPlatformVersionFromWeb = page.getFirstByXPath(elementQuarkusPlatformVersionByXpath);
+        String quarkusPlatformVersionFromWeb = page.locator(elementQuarkusPlatformVersionByXpath).elementHandle().getAttribute("title");
 
         assertNotNull(quarkusPlatformVersionFromWeb, "Element: " + elementQuarkusPlatformVersionByXpath + " is missing!");
         assertTrue(quarkusPlatformVersionFromWeb.contains(quarkusPlatformVersion),
@@ -116,21 +121,12 @@ public class CodeQuarkusSiteTest {
     }
 
 
-    public HtmlPage loadPage(String url, int timeoutSeconds) throws InterruptedException {
-        HtmlPage page = null;
-        long startTime = System.currentTimeMillis();
-        long endTime = startTime + timeoutSeconds * 1000;
+    public Page loadPage(String url, int timeoutSeconds) {
         LOGGER.info("Loading web page " + url);
-        try {
-            page = webClient.getPage(url);
-        } catch (Exception e) {
-            throw new RuntimeException("Cannot load the page: " + webPageUrl);
-        }
-        JavaScriptJobManager manager = page.getEnclosingWindow().getJobManager();
-        while (manager.getJobCount() > 0 && System.currentTimeMillis() < endTime) {
-            Thread.sleep(1000);
-        }
-
+        Page page = browserContext.newPage(); // this will create new tab inside browser
+        page.setDefaultTimeout(timeoutSeconds * 1000);
+        page.navigate(url);
+        page.waitForSelector(pageLoadedSelector);
         return page;
     }
 }


### PR DESCRIPTION
Playwright provides better API and has better JS support than htmlunit
Documentation is also better https://playwright.dev/java/docs/selectors/#quick-guide

Trello card with description of effort: https://trello.com/c/gqAsh7s6/1083-update-startstopts-tests-for-codequarkus-site-there-was-set-of-updates-to-enable-quarkiverse-extensions