### PR TITLE
[2.2] Ensure page with extension entries is loaded

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -36,6 +36,7 @@ public class CodeQuarkusSiteTest {
 
     private static final Logger LOGGER = Logger.getLogger(CodeQuarkusSiteTest.class.getName());
 
+    public static final String pageLoadedSelector = ".extension-category";
     public static final String webPageUrl = Commands.getCodeQuarkusURL("https://code.quarkus.redhat.com/");
     public static final String elementTitleByText = "Quarkus - Start coding with code.quarkus.redhat.com";
     public static final String elementIconByXpath = "//link[@rel=\"shortcut icon\"][@href=\"https://www.redhat.com/misc/favicon.ico\"]";


### PR DESCRIPTION
backport: https://github.com/quarkus-qe/quarkus-startstop/pull/145
Only this commit: https://github.com/quarkus-qe/quarkus-startstop/pull/145/commits/a2e2755d172a1acfee4533082cf1cdba327c748f

Depends on: https://github.com/quarkus-qe/quarkus-startstop/pull/150