### PR TITLE
[2.2] Use code.quarkus.redhat.com as default for 2.2 branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build with Maven
         run: |
-          mvn -V -B -s .github/mvn-settings.xml clean verify -Ptestsuite -DincludeTags=codequarkus
+          mvn -V -B -s .github/mvn-settings.xml clean verify -Ptestsuite -DincludeTags=codequarkus -Dgh.actions
       - name: Zip Artifacts
         if: failure()
         run: |

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -97,7 +97,9 @@ public class CodeQuarkusTest {
             LOGGER.info("Unzipping...");
             unzipLog = unzip(zipFile, GEN_BASE_DIR);
             LOGGER.info("Removing repositories and pluginRepositories from pom.xml ...");
-            removeRepositoriesAndPluginRepositories(appDir + File.separator + "pom.xml");
+            if (StringUtils.isBlank(System.getProperty("gh.actions"))) {
+                removeRepositoriesAndPluginRepositories(appDir + File.separator + "pom.xml");
+            }
             adjustPrettyPrintForJsonLogging(appDir.getAbsolutePath());
             disableDevServices(appDir.getAbsolutePath());
             List<String> cmd;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -173,7 +173,7 @@ public class Commands {
     }
 
     public static String getCodeQuarkusURL() {
-        return getCodeQuarkusURL("https://code.quarkus.io");
+        return getCodeQuarkusURL("https://code.quarkus.redhat.com");
     }
 
     public static String getCodeQuarkusURL(String fallbackURL) {


### PR DESCRIPTION
Use code.quarkus.redhat.com as default for 2.2 branch

Upstream code.quarkus is rolling target covered by main branch