### PR TITLE
Quarkus 2.7.5 / code.quarkus API related updates

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -63,15 +63,14 @@ public class CodeQuarkusTest {
     public static final List<List<CodeQuarkusExtensions>> notSupportedEx = CodeQuarkusExtensions.partition(1, CodeQuarkusExtensions.Flag.NOT_SUPPORTED);
     public static final List<List<CodeQuarkusExtensions>> mixedEx = CodeQuarkusExtensions.partition(1, CodeQuarkusExtensions.Flag.MIXED);
     
-    public static final Stream<CodeQuarkusExtensions> supportedExWithCodeStarter() {
+    public static final Stream<List<CodeQuarkusExtensions>> supportedExWithCodeStarter() {
         return Arrays.asList(
-                CodeQuarkusExtensions.QUARKUS_SMALLRYE_HEALTH,
-                CodeQuarkusExtensions.QUARKUS_LOGGING_JSON,
-                CodeQuarkusExtensions.QUARKUS_RESTEASY,
-                CodeQuarkusExtensions.QUARKUS_RESTEASY_JACKSON,
-                CodeQuarkusExtensions.QUARKUS_SPRING_WEB,
-                CodeQuarkusExtensions.QUARKUS_WEBSOCKETS,
-                CodeQuarkusExtensions.QUARKUS_QUTE).stream();
+                Arrays.asList(CodeQuarkusExtensions.QUARKUS_SMALLRYE_HEALTH, CodeQuarkusExtensions.QUARKUS_RESTEASY),
+                Arrays.asList(CodeQuarkusExtensions.QUARKUS_LOGGING_JSON, CodeQuarkusExtensions.QUARKUS_RESTEASY),
+                Arrays.asList(CodeQuarkusExtensions.QUARKUS_RESTEASY),
+                Arrays.asList(CodeQuarkusExtensions.QUARKUS_SPRING_WEB),
+                Arrays.asList(CodeQuarkusExtensions.QUARKUS_WEBSOCKETS)
+        ).stream();
     }
 
     public void testRuntime(TestInfo testInfo, List<CodeQuarkusExtensions> extensions, MvnCmds mvnCmds) throws Exception {
@@ -206,7 +205,11 @@ public class CodeQuarkusTest {
     
     @Test
     public void notSupportedExtensionsSubsetB(TestInfo testInfo) throws Exception {
-        testRuntime(testInfo, notSupportedEx.get(0).subList(Math.min(10, notSupportedEx.get(0).size()), Math.min(20, notSupportedEx.get(0).size())), MvnCmds.MVNW_DEV);
+        List<CodeQuarkusExtensions> notSupportedExtensionsSubsetB = notSupportedEx.get(0).subList(Math.min(10, notSupportedEx.get(0).size()), Math.min(20, notSupportedEx.get(0).size()));
+        // resteasy or spring-web extension is needed to provide index.html file
+        // content from index.html file is checked to ensure the application is up and running
+        notSupportedExtensionsSubsetB.add(CodeQuarkusExtensions.QUARKUS_RESTEASY);
+        testRuntime(testInfo, notSupportedExtensionsSubsetB, MvnCmds.MVNW_DEV);
     }
 
     @Test
@@ -241,24 +244,14 @@ public class CodeQuarkusTest {
 
     @ParameterizedTest
     @MethodSource("supportedExWithCodeStarter")
-    public void supportedExtensionWithCodeStarterWorksInJVM(CodeQuarkusExtensions extension, TestInfo testInfo) throws Exception {
-        List<CodeQuarkusExtensions> extensions = new ArrayList<>();
-        extensions.add(extension);
-        if (extension.equals(CodeQuarkusExtensions.QUARKUS_SMALLRYE_HEALTH)) {
-            extensions.add(CodeQuarkusExtensions.QUARKUS_RESTEASY);
-        }
+    public void supportedExtensionWithCodeStarterWorksInJVM(List<CodeQuarkusExtensions> extensions, TestInfo testInfo) throws Exception {
         testRuntime(testInfo, extensions, MvnCmds.MVNW_JVM);
     }
     
     @Tag("native")
     @ParameterizedTest
     @MethodSource("supportedExWithCodeStarter")
-    public void supportedExtensionWithCodeStarterWorksInNative(CodeQuarkusExtensions extension, TestInfo testInfo) throws Exception {
-        List<CodeQuarkusExtensions> extensions = new ArrayList<>();
-        extensions.add(extension);
-        if (extension.equals(CodeQuarkusExtensions.QUARKUS_SMALLRYE_HEALTH)) {
-            extensions.add(CodeQuarkusExtensions.QUARKUS_RESTEASY);
-        }
+    public void supportedExtensionWithCodeStarterWorksInNative(List<CodeQuarkusExtensions> extensions, TestInfo testInfo) throws Exception {
         testRuntime(testInfo, extensions, MvnCmds.MVNW_NATIVE);
     }
 }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
@@ -164,6 +164,8 @@ public enum CodeQuarkusExtensions {
     QUARKUS_OIDC_CLIENT_FILTER("quarkus-oidc-client-filter", "OpenID Connect Client Filter", "T0U", true),
     // TODO Introduce buckets with reactive jax-rs extensions
 //    QUARKUS_OIDC_CLIENT_REACTIVE_FILTER("quarkus-oidc-client-reactive-filter", "OpenID Connect Client Filter Reactive", "YqA", false),
+    // TODO Introduce buckets with reactive jax-rs extensions
+//    QUARKUS_OIDC_TOKEN_PROPAGATION_REACTIVE("quarkus-oidc-token-propagation-reactive", "OpenID Connect Token Propagation Reactive", "ignored", false),
     QUARKUS_OIDC_TOKEN_PROPAGATION("quarkus-oidc-token-propagation", "OpenID Connect Token Propagation", "Bg9", false),
     QUARKUS_SECURITY_JPA("quarkus-security-jpa", "Security JPA", "W8w", false),
     QUARKUS_SMALLRYE_JWT_BUILD("quarkus-smallrye-jwt-build", "SmallRye JWT Build", "Phi", true),

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -310,8 +310,8 @@ public class Commands {
      * @throws IOException
      */
     public static String download(Collection<CodeQuarkusExtensions> extensions, String destinationZipFile) throws IOException {
-        String downloadURL = getCodeQuarkusURL() + "/api/download?s=" +
-                extensions.stream().map(x -> x.shortId).collect(Collectors.joining("."));
+        String downloadURL = getCodeQuarkusURL() + "/api/download?" +
+                extensions.stream().map(x -> "e=" + x.id).collect(Collectors.joining("&"));
         return download(downloadURL, destinationZipFile);
     }
 
@@ -326,7 +326,7 @@ public class Commands {
      */
     public static String download(Collection<CodeQuarkusExtensions> extensions, String destinationZipFile, int javaVersion) throws IOException {
         String downloadURL = getCodeQuarkusURL() + "/api/download?s=" +
-                extensions.stream().map(x -> x.shortId).collect(Collectors.joining(".")) +
+                extensions.stream().map(x -> "e=" + x.id).collect(Collectors.joining("&")) +
                 "&j=" + javaVersion;
         return download(downloadURL, destinationZipFile);
     }


### PR DESCRIPTION
Quarkus 2.7.5 / code.quarkus API related updates

 - Stop using shortId approach which was removed from the API
 - quarkus-oidc-token-propagation-reactive extension added in Quarkus 2.7.1.Final 
 - Update of tested extensions with codestart, added RESTEasy extension where needed 

