### PR TITLE
Increase windows.jvm.RSS.threshold.kB to mitigate GH Actions instabilities

### DIFF
--- a/app-full-microprofile/threshold.properties
+++ b/app-full-microprofile/threshold.properties
@@ -3,6 +3,6 @@ linux.jvm.RSS.threshold.kB=550000
 linux.native.time.to.first.ok.request.threshold.ms=60
 linux.native.RSS.threshold.kB=120000
 windows.jvm.time.to.first.ok.request.threshold.ms=4500
-windows.jvm.RSS.threshold.kB=4600
+windows.jvm.RSS.threshold.kB=5000
 windows.native.time.to.first.ok.request.threshold.ms=1600
 windows.native.RSS.threshold.kB=120000

--- a/app-jax-rs-minimal/threshold.properties
+++ b/app-jax-rs-minimal/threshold.properties
@@ -3,6 +3,6 @@ linux.jvm.RSS.threshold.kB=380000
 linux.native.time.to.first.ok.request.threshold.ms=35
 linux.native.RSS.threshold.kB=90000
 windows.jvm.time.to.first.ok.request.threshold.ms=4500
-windows.jvm.RSS.threshold.kB=4500
+windows.jvm.RSS.threshold.kB=4800
 windows.native.time.to.first.ok.request.threshold.ms=800
 windows.native.RSS.threshold.kB=90000


### PR DESCRIPTION
Increase windows.jvm.RSS.threshold.kB to mitigate GH Actions instabilities

Results are right under the threshold, sometimes going above by few kB.
Current limit was quite low, even the updated one is still quite low. But let's do the threshold updates step by step.