### PR TITLE
Bump Quarkus from 2.7.5.Final to 2.9.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>2.7.5.Final</quarkus.version>
+        <quarkus.version>2.9.2.Final</quarkus.version>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus-ide-config.version>2.5.1.Final</quarkus-ide-config.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -91,7 +91,7 @@ public class ArtifactGeneratorTest {
             "spring-data-jpa",
             "spring-di",
             "spring-security",
-            "spring-web",
+//            "spring-web",  // spring-web-codestart uses quarkus-resteasy-reactive-jackson, see https://github.com/quarkusio/quarkus/pull/24890
             "undertow",
             "vertx",
             "quarkus-reactive-routes",
@@ -140,7 +140,7 @@ public class ArtifactGeneratorTest {
             "spring-data-rest",
             "spring-di",
             "spring-security",
-            "spring-web",
+//            "spring-web",  // spring-web-codestart uses quarkus-resteasy-reactive-jackson, see https://github.com/quarkusio/quarkus/pull/24890
             "spring-cloud-config-client",
             "spring-scheduled",
             "spring-cache",
@@ -177,8 +177,7 @@ public class ArtifactGeneratorTest {
             "spring-data-jpa",
             "spring-di",
             "spring-security",
-            // codestart is problematic with reactive - https://issues.redhat.com/browse/QUARKUS-1300 / https://github.com/quarkusio/quarkus/issues/23265
-//            "spring-web",
+            "spring-web",
             "undertow",
             "vertx",
             "quarkus-reactive-routes",
@@ -229,8 +228,7 @@ public class ArtifactGeneratorTest {
             "spring-data-rest",
             "spring-di",
             "spring-security",
-            // codestart is problematic with reactive - https://issues.redhat.com/browse/QUARKUS-1300 / https://github.com/quarkusio/quarkus/issues/23265
-//            "spring-web",
+            "spring-web",
             "spring-cloud-config-client",
             "spring-scheduled",
             "spring-cache",
@@ -311,8 +309,7 @@ public class ArtifactGeneratorTest {
             LOGGER.info("Testing reload...");
             // modify existing class
             Path srcFile = Paths.get(appDir + File.separator + "src" + File.separator + "main" + File.separator + "java" + File.separator +
-                    "org" + File.separator + "my" + File.separator + "group" + File.separator +
-                    (flags.contains(TestFlags.RESTEASY_REACTIVE)?"ReactiveGreetingResource.java":"GreetingController.java"));
+                    "org" + File.separator + "my" + File.separator + "group" + File.separator +"GreetingResource.java");
             appendlnSection(whatIDidReport, "Reloading class: " + srcFile.toAbsolutePath());
             try (Stream<String> src = Files.lines(srcFile)) {
                 Files.write(srcFile, src.map(l -> l.replaceAll("Hello", "Bye")).collect(Collectors.toList()));

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/URLContent.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/URLContent.java
@@ -23,9 +23,9 @@ public enum URLContent {
     }),
     GENERATED_SKELETON(new String[][]{
             new String[]{"http://localhost:8080", "Congratulations"},
-            new String[]{"http://localhost:8080/greeting", "Bye Spring"},
+            new String[]{"http://localhost:8080/hello", "Bye RESTEasy"},
             new String[]{"http://localhost:8080/hello-added", "Hello added"},
-            new String[]{"http://localhost:8080/hello", "Bye RESTEasy Reactive"},
+            new String[]{"http://localhost:8080/hello", "Bye from RESTEasy Reactive"},
     });
 
     public final String[][] urlContent;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -19,6 +19,7 @@ public enum WhitelistLogLines {
             Pattern.compile(".*TestSecureController.java.*"),
             // Well, the RestClient demo probably should do some cleanup before shutdown...?
             Pattern.compile(".*Closing a class org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient.*"),
+            Pattern.compile(".*GC warning.*"),
     }),
     GENERATED_SKELETON(new Pattern[]{
             // It so happens that the dummy skeleton tries to find Mongo. This is expected.

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -84,6 +84,8 @@ public enum WhitelistLogLines {
             Pattern.compile(".*Unable to properly register the hierarchy of the following classes for reflection as they are not in the Jandex index.*"),
             // https://github.com/quarkusio/quarkus/issues/23387
             Pattern.compile(".*The configuration.*auto.offset.reset.* was supplied but isn't a known config.*"),
+            // https://github.com/quarkusio/quarkus/issues/25821
+            Pattern.compile(".*Failed to index org.springframework.web.bind.annotation.Mapping: Class does not exist in ClassLoader.*"),
     }),
     // Quarkus is not being gratefully shutdown in Windows when running in Dev mode.
     // Reported by https://github.com/quarkusio/quarkus/issues/14647.


### PR DESCRIPTION
Bump Quarkus from 2.7.5.Final to 2.9.2.Final

 - codestarts for RESTEasy and RESTEasy Reactive synced  to have the same endpoint and same file name
 - changes in spring-web codestart
 - one issue found