### PR TITLE
Make sure at least 2 streams are defined on code.quarkus

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -122,9 +122,8 @@ public class CodeQuarkusSiteTest {
         streamPicker.click();
         Locator streamItems = page.locator(elementStreamItemsByXpath);
         assertTrue(streamItems.count() > 0, "No stream is defined");
-//        assertTrue(streamItems.count() > 1, "Just one stream is defined, streamItems count: " + streamItems.count() + "\n" +
-//                "Please make sure the 2 months period for 2 supported streams applies before filing issue for the product. \n" +
-//                "Product Update and Support Policy: https://access.redhat.com/support/policy/updates/jboss_notes#p_quarkus");
+        assertTrue(streamItems.count() > 1, "Two (or more) streams are expected to be defined defined, streamItems count: " + streamItems.count() + "\n" +
+                "Product Update and Support Policy: https://access.redhat.com/support/policy/updates/jboss_notes#p_quarkus");
     }
 
     @Test


### PR DESCRIPTION
Make sure at least 2 streams are defined on code.quarkus

RHBQ 2.7 was released, https://code.quarkus.redhat.com/ has 2 versions defined.
Thomas said he doesn't want to remove 2.2 version definition.