### PR TITLE
Update native image builders - use version 22.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,7 +159,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: [ "21.3.0.java11" ]
+        graalvm-version: [ "22.2.0.java11" ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Example command:
 mvn clean verify -Ptestsuite -Dtest=SpecialCharsTest#diacriticsNative \
     -Dquarkus.version=1.6.0.Final -Dquarkus.platform.version=1.6.0.Final \
     -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=docker\
-    -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:20.1.0-java11
+    -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:22.2.0-java11
 ```
 
 ## Values


### PR DESCRIPTION
Updates GraalVM/Mandrel version to 22.2.