### PR TITLE
Use method name based directory for generator tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: "CI"
+name: "StartStop CI"
 on:
   pull_request:
   workflow_dispatch:
@@ -89,7 +89,7 @@ jobs:
             name: ci-artifacts
             path: artifacts-native${{ matrix.java }}.zip
   linux-build-code-start:
-    name: Linux - Code Quarkus build
+    name: Linux - Code Quarkus
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
@@ -63,7 +63,7 @@ public class ArtifactGeneratorBOMTest {
         StringBuilder whatIDidReport = new StringBuilder();
         String cn = testInfo.getTestClass().get().getCanonicalName();
         String mn = testInfo.getTestMethod().get().getName();
-        File appBaseDir = new File(getArtifactGeneBaseDir());
+        File appBaseDir = new File(getArtifactGeneBaseDir(), mn);
         File appDir = new File(appBaseDir, Apps.GENERATED_SKELETON.dir);
         String logsDir = appBaseDir.getAbsolutePath() + File.separator + Apps.GENERATED_SKELETON.dir + "-logs";
         String repoDir = getLocalMavenRepoDir();
@@ -78,7 +78,7 @@ public class ArtifactGeneratorBOMTest {
 
         try {
             // Cleanup
-            cleanDirOrFile(appDir.getAbsolutePath(), logsDir);
+            cleanDirOrFile(appBaseDir.getAbsolutePath());
             Files.createDirectories(Paths.get(logsDir));
             Files.createDirectories(Paths.get(repoDir));
 
@@ -153,7 +153,7 @@ public class ArtifactGeneratorBOMTest {
                 archiveLog(cn, mn, runLogA);
             }
             writeReport(cn, mn, whatIDidReport.toString());
-            cleanDirOrFile(appDir.getAbsolutePath(), logsDir);
+            cleanDirOrFile(appBaseDir.getAbsolutePath());
         }
     }
 

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -244,7 +244,7 @@ public class ArtifactGeneratorTest {
         StringBuilder whatIDidReport = new StringBuilder();
         String cn = testInfo.getTestClass().get().getCanonicalName();
         String mn = testInfo.getTestMethod().get().getName();
-        File appBaseDir = new File(getArtifactGeneBaseDir());
+        File appBaseDir = new File(getArtifactGeneBaseDir(), mn);
         File appDir = new File(appBaseDir, Apps.GENERATED_SKELETON.dir);
         String logsDir = appBaseDir.getAbsolutePath() + File.separator + Apps.GENERATED_SKELETON.dir + "-logs";
         List<String> generatorCmd = getGeneratorCommand(MvnCmds.GENERATOR.mvnCmds[0], extensions);
@@ -258,7 +258,7 @@ public class ArtifactGeneratorTest {
 
         try {
             // Cleanup
-            cleanDirOrFile(appDir.getAbsolutePath(), logsDir);
+            cleanDirOrFile(appBaseDir.getAbsolutePath());
             Files.createDirectories(Paths.get(logsDir));
 
             // Build
@@ -374,7 +374,7 @@ public class ArtifactGeneratorTest {
                 archiveLog(cn, mn, runLogA);
             }
             writeReport(cn, mn, whatIDidReport.toString());
-            cleanDirOrFile(appDir.getAbsolutePath(), logsDir);
+            cleanDirOrFile(appBaseDir.getAbsolutePath());
         }
     }
 


### PR DESCRIPTION
 + Use method name based directory for generator tests
 + Minor update to use a bit longer root GH Action name, code.quarkus name update 

Method name based directory for generator tests prevents the issue we see from time to time on Windows machines with slow IO - like in this run https://github.com/quarkus-qe/quarkus-startstop/actions/runs/3078997244