### PR TITLE
Move to Quarkus 2.13.0.Final, force Java 11 for code.quarkus apps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>2.13.0.CR1</quarkus.version>
+        <quarkus.version>2.13.0.Final</quarkus.version>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus-ide-config.version>2.5.1.Final</quarkus-ide-config.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -93,7 +93,7 @@ public class CodeQuarkusTest {
             appendln(whatIDidReport, "# " + cn + ", " + mn);
             appendln(whatIDidReport, (new Date()).toString());
             LOGGER.info("Downloading...");
-            appendln(whatIDidReport, "Download URL: " + download(extensions, zipFile));
+            appendln(whatIDidReport, "Download URL: " + download(extensions, zipFile, 11));
             LOGGER.info("Unzipping...");
             unzipLog = unzip(zipFile, GEN_BASE_DIR);
             LOGGER.info("Removing repositories and pluginRepositories from pom.xml ...");
@@ -178,9 +178,8 @@ public class CodeQuarkusTest {
     @Test
     public void supportedExtensionsSubsetB(TestInfo testInfo) throws Exception {
         List<CodeQuarkusExtensions> supportedExtensionsSubsetB = supportedEx.get(1);
-        // quarkus-reactive-routes extension to open port 8080 and provide index.html file
-        // https://github.com/quarkusio/quarkus/issues/21132
-        supportedExtensionsSubsetB.add(CodeQuarkusExtensions.QUARKUS_REACTIVE_ROUTES);
+        // resteasy-reactive extension to open port 8080 and provide index.html file
+        supportedExtensionsSubsetB.add(CodeQuarkusExtensions.QUARKUS_RESTEASY_REACTIVE);
         testRuntime(testInfo, supportedExtensionsSubsetB, MvnCmds.MVNW_DEV);
     }
 


### PR DESCRIPTION
Move to Quarkus 2.13.0.Final, force Java 11 for code.quarkus apps