### PR TITLE
Drop OpenTelemetry Jaeger exporter

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
@@ -150,7 +150,6 @@ public enum CodeQuarkusExtensions {
     QUARKUS_MICROMETER("quarkus-micrometer", "Micrometer metrics", "Svz", true),
     QUARKUS_MICROMETER_REGISTRY_PROMETHEUS("quarkus-micrometer-registry-prometheus", "Micrometer Registry Prometheus", "DTu", true),
     QUARKUS_OPENTELEMETRY("quarkus-opentelemetry", "OpenTelemetry", "y6J", false),
-    QUARKUS_OPENTELEMETRY_EXPORTER_JAEGER("quarkus-opentelemetry-exporter-jaeger", "OpenTelemetry exporter: Jaeger", "DTW", false),
     QUARKUS_OPENTELEMETRY_EXPORTER_OTLP("quarkus-opentelemetry-exporter-otlp", "OpenTelemetry exporter: OTLP", "CGl", false),
     QUARKUS_SMALLRYE_METRICS("quarkus-smallrye-metrics", "SmallRye Metrics", "Ll4", false), //intentionally because of micrometer
     QUARKUS_SMALLRYE_OPENTRACING("quarkus-smallrye-opentracing", "SmallRye OpenTracing", "f7", true),


### PR DESCRIPTION
TP: https://github.com/quarkus-qe/quarkus-test-plans/pull/102

Please be sure that extension is already removed on [code.quarkus.io](https://code.quarkus.io/?extension-search=origin:platform%20quarkus-opentelemetry-exporter-jaeger)