### PR TITLE
Bump Quarkus to 2.13.2.Final

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,7 +159,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: [ "22.2.0.java11" ]
+        graalvm-version: [ "22.2.0.java17" ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>2.13.0.Final</quarkus.version>
+        <quarkus.version>2.13.2.Final</quarkus.version>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus-ide-config.version>2.5.1.Final</quarkus-ide-config.version>
         <maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
Bump Quarkus to 2.13.2.Final

Java 17 based GraalVM is the default starting Quarkus 2.13