### PR TITLE
Bump first.ok.request.threshold.ms to 40ms for app-jax-rs-minimal

### DIFF
--- a/app-jax-rs-minimal/threshold.properties
+++ b/app-jax-rs-minimal/threshold.properties
@@ -1,6 +1,6 @@
 linux.jvm.time.to.first.ok.request.threshold.ms=2000
 linux.jvm.RSS.threshold.kB=380000
-linux.native.time.to.first.ok.request.threshold.ms=35
+linux.native.time.to.first.ok.request.threshold.ms=40
 linux.native.RSS.threshold.kB=90000
 windows.jvm.time.to.first.ok.request.threshold.ms=4500
 windows.jvm.RSS.threshold.kB=4800


### PR DESCRIPTION
Bump first.ok.request.threshold.ms to 40ms for app-jax-rs-minimal

Investigation for the increase is tracked in https://issues.redhat.com/browse/QUARKUS-2456