### PR TITLE
[2.7] Coverage for quarkus-qpid-jms, make sure released RH artifacts are not used

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build with Maven
         run: |
-          mvn -V -B -s .github/mvn-settings.xml clean verify -DexcludeTags=product,native,codequarkus
+          mvn -V -B -s .github/mvn-settings.xml clean verify -DexcludeTags=product,native,codequarkus -Dgh.actions
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -77,7 +77,7 @@ jobs:
             java-version: ${{ matrix.java }}
         - name: Build with Maven
           run: |
-            mvn -V -B -s .github/mvn-settings.xml clean verify -DexcludeTags=product,codequarkus -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=docker
+            mvn -V -B -s .github/mvn-settings.xml clean verify -DexcludeTags=product,codequarkus -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=docker -Dgh.actions
         - name: Zip Artifacts
           if: failure()
           run: |
@@ -140,7 +140,7 @@ jobs:
       - name: Build with Maven
         shell: bash
         run: |
-          mvn -V -B -s .github/mvn-settings.xml clean verify -DexcludeTags='product,native,codequarkus'
+          mvn -V -B -s .github/mvn-settings.xml clean verify -DexcludeTags='product,native,codequarkus' -Dgh.actions
       - name: Zip Artifacts
         if: failure()
         shell: bash
@@ -190,7 +190,7 @@ jobs:
         uses: al-cheb/configure-pagefile-action@v1.2
       - name: Build with Maven
         run: |
-          mvn -V -B -s .github/mvn-settings.xml clean verify -DexcludeTags="product,codequarkus" -Dquarkus.native.native-image-xmx=6g
+          mvn -V -B -s .github/mvn-settings.xml clean verify -DexcludeTags="product,codequarkus" -Dquarkus.native.native-image-xmx=6g -Dgh.actions
         shell: cmd
       - name: Zip Artifacts
         if: failure()

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
@@ -6,6 +6,7 @@ import io.quarkus.ts.startstop.utils.MvnCmds;
 import io.quarkus.ts.startstop.utils.TestFlags;
 import io.quarkus.ts.startstop.utils.URLContent;
 import io.quarkus.ts.startstop.utils.WebpageTester;
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,7 @@ import static io.quarkus.ts.startstop.utils.Commands.getLocalMavenRepoDir;
 import static io.quarkus.ts.startstop.utils.Commands.getRunCommand;
 import static io.quarkus.ts.startstop.utils.Commands.parsePort;
 import static io.quarkus.ts.startstop.utils.Commands.processStopper;
+import static io.quarkus.ts.startstop.utils.Commands.removeRepositoriesAndPluginRepositories;
 import static io.quarkus.ts.startstop.utils.Commands.runCommand;
 import static io.quarkus.ts.startstop.utils.Commands.waitForTcpClosed;
 import static io.quarkus.ts.startstop.utils.Logs.appendln;
@@ -101,6 +103,10 @@ public class ArtifactGeneratorBOMTest {
             confAppPropsForSkeleton(appDir.getAbsolutePath());
             adjustPrettyPrintForJsonLogging(appDir.getAbsolutePath());
             dropEntityAnnotations(appDir.getAbsolutePath());
+            if (StringUtils.isBlank(System.getProperty("gh.actions"))) {
+                LOGGER.info("Removing repositories and pluginRepositories from pom.xml ...");
+                removeRepositoriesAndPluginRepositories(appDir + File.separator + "pom.xml");
+            }
 
             // Build
             LOGGER.info(mn + ": Build command " + String.join(" ", buildCmd));

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -12,6 +12,7 @@ import static io.quarkus.ts.startstop.utils.Commands.getRSSkB;
 import static io.quarkus.ts.startstop.utils.Commands.getRunCommand;
 import static io.quarkus.ts.startstop.utils.Commands.parsePort;
 import static io.quarkus.ts.startstop.utils.Commands.processStopper;
+import static io.quarkus.ts.startstop.utils.Commands.removeRepositoriesAndPluginRepositories;
 import static io.quarkus.ts.startstop.utils.Commands.runCommand;
 import static io.quarkus.ts.startstop.utils.Commands.waitForTcpClosed;
 import static io.quarkus.ts.startstop.utils.Logs.SKIP;
@@ -39,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -102,6 +104,7 @@ public class ArtifactGeneratorTest {
             "micrometer-registry-prometheus",
             "quarkus-openshift-client",
             "quarkus-smallrye-graphql-client",
+            "qpid-jms",
     };
 
     public static final String[] supportedExtensionsSubsetSetB = new String[]{
@@ -283,6 +286,10 @@ public class ArtifactGeneratorTest {
             confAppPropsForSkeleton(appDir.getAbsolutePath());
             adjustPrettyPrintForJsonLogging(appDir.getAbsolutePath());
             dropEntityAnnotations(appDir.getAbsolutePath());
+            if (StringUtils.isBlank(System.getProperty("gh.actions"))) {
+                LOGGER.info("Removing repositories and pluginRepositories from pom.xml ...");
+                removeRepositoriesAndPluginRepositories(appDir + File.separator + "pom.xml");
+            }
 
             // Run
             LOGGER.info("Running... " + runCmd);

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
@@ -97,7 +97,7 @@ public enum CodeQuarkusExtensions {
     QUARKUS_SMALLRYE_REACTIVE_MESSAGING_KAFKA("quarkus-smallrye-reactive-messaging-kafka", "SmallRye Reactive Messaging - Kafka Connector", "9qf", true),
     QUARKUS_SMALLRYE_REACTIVE_MESSAGING_MQTT("quarkus-smallrye-reactive-messaging-mqtt", "SmallRye Reactive Messaging - MQTT Connector", "ZsB", false),
     QUARKUS_SMALLRYE_REACTIVE_MESSAGING_RABBITMQ("quarkus-smallrye-reactive-messaging-rabbitmq", "SmallRye Reactive Messaging - RabbitMQ Connector", "haH", false),
-    QUARKUS_QPID_JMS("quarkus-qpid-jms", "AMQP 1.0 JMS client - Apache Qpid JMS", "Zdm", false),
+    QUARKUS_QPID_JMS("quarkus-qpid-jms", "AMQP 1.0 JMS client - Apache Qpid JMS", "Zdm", true),
     QUARKUS_KAFKA_CLIENT("quarkus-kafka-client", "Apache Kafka Client", "FKK", true),
     // SRCFG00014: Property quarkus.kafka-streams.topics is required but the value was not found or is empty
     // https://github.com/quarkusio/quarkus/issues/8506


### PR DESCRIPTION
Coverage for quarkus-qpid-jms, make sure released RH artifacts are not used

code.quarkus will faill till SP2 is out