### PR TITLE
2.13 upstream artifacts whitelist plus qpid

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -104,7 +104,7 @@ public class ArtifactGeneratorTest {
             "micrometer-registry-prometheus",
             "quarkus-openshift-client",
             "quarkus-smallrye-graphql-client",
-            "qpid-jms",
+//            "qpid-jms",  // not part of the initial RHBQ 2.13 release
     };
 
     public static final String[] supportedExtensionsSubsetSetB = new String[]{

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
@@ -18,6 +18,7 @@ public enum WhitelistProductBomJars {
             "com.graphql-java.graphql-java",
             "com.graphql-java.java-dataloader",
             "org.apache.thrift.libthrift",
+            "com.aayushatharva.brotli4j.native-osx-x86_64",
     });
 
     public final String[] jarNames;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
@@ -13,6 +13,11 @@ public enum WhitelistProductBomJars {
             "com.nimbusds.oauth2-oidc-sdk",
             "com.nimbusds.content-type",
             "io.github.crac",
+            "org.jboss.spec.javax.resource.jboss-connector-api_1.7_spec",
+            "io.perfmark.perfmark-api",
+            "com.graphql-java.graphql-java",
+            "com.graphql-java.java-dataloader",
+            "org.apache.thrift.libthrift",
     });
 
     public final String[] jarNames;


### PR DESCRIPTION
 - QPID JMS is not part of the initial RHBQ 2.13 release
 - Whitelist artifacts highlighted in QUARKUS-2691
 - Whitelist brotli4j.native-osx-x86_64 for macOS, relates to QUARKUS-2694

2.13 branch only PR