### PR TITLE
Minor fixes

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
@@ -38,6 +38,7 @@ import static io.quarkus.ts.startstop.utils.Commands.parsePort;
 import static io.quarkus.ts.startstop.utils.Commands.processStopper;
 import static io.quarkus.ts.startstop.utils.Commands.runCommand;
 import static io.quarkus.ts.startstop.utils.Commands.waitForTcpClosed;
+import static io.quarkus.ts.startstop.utils.Commands.disableCleanup;
 import static io.quarkus.ts.startstop.utils.Logs.SKIP;
 import static io.quarkus.ts.startstop.utils.Logs.appendln;
 import static io.quarkus.ts.startstop.utils.Logs.appendlnSection;
@@ -63,6 +64,7 @@ public class StartStopTest {
 
     public void testRuntime(TestInfo testInfo, Apps app, MvnCmds mvnCmds) throws IOException, InterruptedException {
         LOGGER.info("Testing app: " + app.toString() + ", mode: " + mvnCmds.toString());
+        LOGGER.info("Cleanup Enabled: " + !disableCleanup());
 
         Process pA = null;
         File buildLogA = null;
@@ -178,7 +180,9 @@ public class StartStopTest {
             archiveLog(cn, mn, buildLogA);
             archiveLog(cn, mn, runLogA);
             writeReport(cn, mn, whatIDidReport.toString());
-            cleanTarget(app);
+            if ( !disableCleanup() ){
+                cleanTarget(app);
+            }
         }
     }
 

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
@@ -96,6 +96,9 @@ public class StartStopTest {
             buildService.awaitTermination(30, TimeUnit.MINUTES);
             long buildEnds = System.currentTimeMillis();
 
+            assertTrue(buildLogA.exists());
+            checkLog(cn, mn, app, mvnCmds, buildLogA);
+
             if (mvnCmds == MvnCmds.NATIVE) {
                 String nativeBinaryLocation = mvnCmds.mvnCmds[1][0];
                 Path nativeBinaryPath = Paths.get(appDir.getAbsolutePath(), nativeBinaryLocation);
@@ -105,9 +108,6 @@ public class StartStopTest {
                 LOGGER.info("Native binary SIZE: " + prettySize);
                 appendlnSection(whatIDidReport, "   SIZE: " + prettySize);
             }
-
-            assertTrue(buildLogA.exists());
-            checkLog(cn, mn, app, mvnCmds, buildLogA);
 
             List<Long> rssKbList = new ArrayList<>(10);
             List<Long> timeToFirstOKRequestList = new ArrayList<>(10);

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -161,15 +161,19 @@ public class Commands {
     }
 
     public static String getBaseDir() {
-        String env = System.getenv().get("basedir");
-        String sys = System.getProperty("basedir");
-        if (StringUtils.isNotBlank(env)) {
-            return new File(env).getParent();
+        String baseDir = System.getenv().get("basedir");
+        if ( baseDir == null ) {
+            baseDir = System.getProperty("basedir");
         }
-        if (StringUtils.isBlank(sys)) {
+        if (baseDir == null) {
+            // IDE PWD env variable
+            baseDir = System.getenv().get("PWD");
+        }
+
+        if (StringUtils.isBlank(baseDir)) {
             throw new IllegalArgumentException("Unable to determine project.basedir.");
         }
-        return new File(sys).getParent();
+        return new File(baseDir).getParent();
     }
 
     public static String getCodeQuarkusURL() {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -607,6 +607,15 @@ public class Commands {
         pidKiller(p.pid(), force);
     }
 
+    public static boolean disableCleanup(){
+
+        if (System.getProperty("disableCleanup") != null) {
+            return true;
+        }
+
+        return false;
+    }
+
     private static void disableSslVerification() {
         try
         {


### PR DESCRIPTION
 - Allow runing in intellij
 - Provide `-DdisableCleaup` option to disable cleanup of artefacts, allows easier debugging
 - Validate build logs before trying to capture native image stats.
