### PR TITLE
[2.13] Download apps from 2.13 stream

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -333,7 +333,7 @@ public class Commands {
     public static String download(Collection<CodeQuarkusExtensions> extensions, String destinationZipFile, int javaVersion) throws IOException {
         String downloadURL = getCodeQuarkusURL() + "/api/download?" +
                 extensions.stream().map(x -> "e=" + x.id).collect(Collectors.joining("&")) +
-                "&j=" + javaVersion;
+                "&j=" + javaVersion + "&S=2.13";
         return download(downloadURL, destinationZipFile);
     }
 


### PR DESCRIPTION
Download apps from 2.13 stream

CodeQuarkus tests are Quarkus version agnostic, they run against the instance and check if the app can be built / used, thus we should define stream in code. We can't rely on parsing from Quarkus version.
