### PR TITLE
Remove repositories definition for code.quarkus tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build with Maven
         run: |
-          mvn -V -B -s .github/mvn-settings.xml clean verify -Ptestsuite -DincludeTags=codequarkus
+          mvn -V -B -s .github/mvn-settings.xml clean verify -Ptestsuite -DincludeTags=codequarkus -Dgh.actions
       - name: Zip Artifacts
         if: failure()
         run: |

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -96,7 +96,10 @@ public class CodeQuarkusTest {
             appendln(whatIDidReport, "Download URL: " + download(extensions, zipFile, 11));
             LOGGER.info("Unzipping...");
             unzipLog = unzip(zipFile, GEN_BASE_DIR);
-            LOGGER.info("Removing repositories and pluginRepositories from pom.xml ...");
+            if (StringUtils.isBlank(System.getProperty("gh.actions"))) {
+                LOGGER.info("Removing repositories and pluginRepositories from pom.xml ...");
+                removeRepositoriesAndPluginRepositories(appDir + File.separator + "pom.xml");
+            }
             removeRepositoriesAndPluginRepositories(appDir + File.separator + "pom.xml");
             adjustPrettyPrintForJsonLogging(appDir.getAbsolutePath());
             disableDevServices(appDir.getAbsolutePath());


### PR DESCRIPTION
Remove repositories definition for code.quarkus tests

Needed for RH based instance, but it's better to have it already in main (less work when backporting)