### PR TITLE
Fix repos removal for code.quarkus

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -100,7 +100,6 @@ public class CodeQuarkusTest {
                 LOGGER.info("Removing repositories and pluginRepositories from pom.xml ...");
                 removeRepositoriesAndPluginRepositories(appDir + File.separator + "pom.xml");
             }
-            removeRepositoriesAndPluginRepositories(appDir + File.separator + "pom.xml");
             adjustPrettyPrintForJsonLogging(appDir.getAbsolutePath());
             disableDevServices(appDir.getAbsolutePath());
             dropEntityAnnotations(appDir.getAbsolutePath());


### PR DESCRIPTION
Fix repos removal for code.quarkus

Line 101 is the right place for the method call, the one on line 103 needs to be dropped

PR https://github.com/quarkus-qe/quarkus-startstop/pull/247 introduce a side effect which would be noticed only when we branch and run against product maven repo zip