### PR TITLE
[2.13] Allow two warnings

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commons.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commons.java
@@ -1,0 +1,8 @@
+package io.quarkus.ts.startstop.utils;
+
+import java.util.regex.Pattern;
+
+public class Commons {
+    static Pattern NETTY_HANDLERS=Pattern.compile(".*Could not register io.netty.handler.codec.*"); //https://github.com/quarkusio/quarkus/issues/30508
+    static Pattern NO_IMAGE = Pattern.compile(".*Tag 22.3-java17 was deleted or has expired.*"); //https://github.com/quarkusio/quarkus/issues/30738
+}

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commons.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commons.java
@@ -3,6 +3,7 @@ package io.quarkus.ts.startstop.utils;
 import java.util.regex.Pattern;
 
 public class Commons {
-    static Pattern NETTY_HANDLERS=Pattern.compile(".*Could not register io.netty.handler.codec.*"); //https://github.com/quarkusio/quarkus/issues/30508
-    static Pattern NO_IMAGE = Pattern.compile(".*Tag 22.3-java17 was deleted or has expired.*"); //https://github.com/quarkusio/quarkus/issues/30738
+    static final Pattern CLOSED_STREAM = Pattern.compile(".*Stream is closed, ignoring and trying to continue.*"); // https://github.com/quarkusio/quarkus/pull/28810
+    static final Pattern STREAM_ERROR = Pattern.compile(".*java.lang.RuntimeException: Error reading stream.*"); // https://github.com/quarkusio/quarkus/issues/28799 (should be removed once 2.14.0.Final is out)
+    static Pattern NETTY_HANDLERS = Pattern.compile(".*Could not register io.netty.handler.codec.*"); //https://github.com/quarkusio/quarkus/issues/30508
 }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -16,6 +16,8 @@ public enum WhitelistLogLines {
             Pattern.compile(".*java.lang.RuntimeException: Error reading stream.*"),
             // https://github.com/quarkusio/quarkus/pull/28810
             Pattern.compile(".*Stream is closed, ignoring and trying to continue.*"),
+            Commons.NETTY_HANDLERS,
+            Commons.NO_IMAGE,
     }),
     FULL_MICROPROFILE(new Pattern[]{
             // Some artifacts names...
@@ -29,26 +31,28 @@ public enum WhitelistLogLines {
             Pattern.compile(".*java.lang.RuntimeException: Error reading stream.*"),
             // https://github.com/quarkusio/quarkus/pull/28810
             Pattern.compile(".*Stream is closed, ignoring and trying to continue.*"),
+            Commons.NETTY_HANDLERS,
+            Commons.NO_IMAGE,
     }),
     GENERATED_SKELETON(new Pattern[]{
             // Harmless warning
             Pattern.compile(".*The Agroal dependency is present but no JDBC datasources have been defined.*"),
             // Due to our not exactly accurate application.properties, these expected warnings occur...
             Pattern.compile(".*Unrecognized configuration key[ \\\\\"]*(" +
-                    "quarkus.oidc.auth-server-url|" +
-                    "quarkus.oidc.client-id|" +
-                    "quarkus.oidc-client.auth-server-url|" +
-                    "quarkus.oidc-client.client-id|" +
-                    "quarkus.oidc-client.token-path|" +
-                    "quarkus.oidc-client.discovery-enabled|" +
-                    "quarkus.smallrye-jwt.enabled|" +
-                    "quarkus.devservices.enabled|" +
-                    "quarkus.jaeger.enabled|" +
-                    "quarkus.jaeger.service-name|" +
-                    "quarkus.jaeger.sampler-param|" +
-                    "quarkus.jaeger.endpoint|" +
-                    "quarkus.jaeger.sampler-type" +
-                    ")[ \\\\\"]*was provided.*"),
+                                    "quarkus.oidc.auth-server-url|" +
+                                    "quarkus.oidc.client-id|" +
+                                    "quarkus.oidc-client.auth-server-url|" +
+                                    "quarkus.oidc-client.client-id|" +
+                                    "quarkus.oidc-client.token-path|" +
+                                    "quarkus.oidc-client.discovery-enabled|" +
+                                    "quarkus.smallrye-jwt.enabled|" +
+                                    "quarkus.devservices.enabled|" +
+                                    "quarkus.jaeger.enabled|" +
+                                    "quarkus.jaeger.service-name|" +
+                                    "quarkus.jaeger.sampler-param|" +
+                                    "quarkus.jaeger.endpoint|" +
+                                    "quarkus.jaeger.sampler-type" +
+                                    ")[ \\\\\"]*was provided.*"),
             // Some artifacts names...
             Pattern.compile(".*maven-error-diagnostics.*"),
             Pattern.compile(".*errorprone.*"),
@@ -81,6 +85,8 @@ public enum WhitelistLogLines {
             Pattern.compile(".*java.lang.RuntimeException: Error reading stream.*"),
             // https://github.com/quarkusio/quarkus/pull/28810
             Pattern.compile(".*Stream is closed, ignoring and trying to continue.*"),
+            Commons.NETTY_HANDLERS,
+            Commons.NO_IMAGE,
     }),
     // Quarkus is not being gratefully shutdown in Windows when running in Dev mode.
     // Reported by https://github.com/quarkusio/quarkus/issues/14647.
@@ -92,7 +98,7 @@ public enum WhitelistLogLines {
             Pattern.compile(".*To see the full stack trace of the errors, re-run Maven with the -e switch.*"),
             Pattern.compile("\\[ERROR\\] *"),
     });
-    
+
     // Depending to the OS and also on the Quarkus extensions, the Native build might print some warnings about duplicate entries
     private static final Pattern COMMON_SLF4J_API_DEPENDENCY_TREE = Pattern.compile(".*org.slf4j:slf4j-api:jar.*");
     private static final Pattern COMMON_SLF4J_JBOSS_LOGMANAGER_DEPENDENCY_TREE = Pattern.compile(".*org.jboss.slf4j:slf4j-jboss-logmanager:jar.*");
@@ -108,14 +114,14 @@ public enum WhitelistLogLines {
     public final Pattern[] platformErrs() {
         switch (OS.current()) {
             case MAC:
-                return new Pattern[] {
+                return new Pattern[]{
                         COMMON_SLF4J_API_DEPENDENCY_TREE,
                         COMMON_SLF4J_JBOSS_LOGMANAGER_DEPENDENCY_TREE,
                         WARNING_MISSING_OBJCOPY_NATIVE,
                         WARNING_MISSING_OBJCOPY_RESULT_NATIVE,
                 };
             case WINDOWS:
-                return new Pattern[] {
+                return new Pattern[]{
                         COMMON_SLF4J_API_DEPENDENCY_TREE,
                         COMMON_SLF4J_JBOSS_LOGMANAGER_DEPENDENCY_TREE,
                         WARNING_MISSING_OBJCOPY_NATIVE,
@@ -124,16 +130,17 @@ public enum WhitelistLogLines {
                         Pattern.compile(".*SLF4J:.*"),
                 };
             case LINUX:
-            	return new Pattern[] {
+                return new Pattern[]{
                         COMMON_SLF4J_API_DEPENDENCY_TREE,
                         COMMON_SLF4J_JBOSS_LOGMANAGER_DEPENDENCY_TREE,
                 };
         }
-        return new Pattern[] {};
+        return new Pattern[]{};
     }
 
     enum OS {
         MAC, LINUX, WINDOWS, UNKNOWN;
+
         public static OS current() {
             if (isMac()) {
                 return MAC;
@@ -146,12 +153,15 @@ public enum WhitelistLogLines {
             }
         }
     }
+
     private static boolean isMac() {
         return System.getProperty("os.name").toLowerCase().contains("mac");
     }
+
     private static boolean isWindows() {
         return System.getProperty("os.name").toLowerCase().contains("windows");
     }
+
     private static boolean isLinux() {
         return System.getProperty("os.name").toLowerCase().contains("linux");
     }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -13,11 +13,9 @@ public enum WhitelistLogLines {
             // https://github.com/quarkusio/quarkus/issues/27307
             Pattern.compile(".*Unknown module: org.graalvm.nativeimage.llvm specified to --add-exports.*"),
             // https://github.com/quarkusio/quarkus/issues/28799 (should be removed once 2.14.0.Final is out)
-            Pattern.compile(".*java.lang.RuntimeException: Error reading stream.*"),
-            // https://github.com/quarkusio/quarkus/pull/28810
-            Pattern.compile(".*Stream is closed, ignoring and trying to continue.*"),
+            Commons.STREAM_ERROR,
+            Commons.CLOSED_STREAM,
             Commons.NETTY_HANDLERS,
-            Commons.NO_IMAGE,
     }),
     FULL_MICROPROFILE(new Pattern[]{
             // Some artifacts names...
@@ -27,12 +25,9 @@ public enum WhitelistLogLines {
             Pattern.compile(".*Closing a class org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient.*"),
             // https://github.com/quarkusio/quarkus/issues/27307
             Pattern.compile(".*Unknown module: org.graalvm.nativeimage.llvm specified to --add-exports.*"),
-            // https://github.com/quarkusio/quarkus/issues/28799 (should be removed once 2.14.0.Final is out)
-            Pattern.compile(".*java.lang.RuntimeException: Error reading stream.*"),
-            // https://github.com/quarkusio/quarkus/pull/28810
-            Pattern.compile(".*Stream is closed, ignoring and trying to continue.*"),
+            Commons.STREAM_ERROR,
+            Commons.CLOSED_STREAM,
             Commons.NETTY_HANDLERS,
-            Commons.NO_IMAGE,
     }),
     GENERATED_SKELETON(new Pattern[]{
             // Harmless warning
@@ -82,11 +77,9 @@ public enum WhitelistLogLines {
             // https://github.com/quarkusio/quarkus/issues/27307
             Pattern.compile(".*Unknown module: org.graalvm.nativeimage.llvm specified to --add-exports.*"),
             // https://github.com/quarkusio/quarkus/issues/28799 (should be removed once 2.14.0.Final is out)
-            Pattern.compile(".*java.lang.RuntimeException: Error reading stream.*"),
-            // https://github.com/quarkusio/quarkus/pull/28810
-            Pattern.compile(".*Stream is closed, ignoring and trying to continue.*"),
+            Commons.STREAM_ERROR,
+            Commons.CLOSED_STREAM,
             Commons.NETTY_HANDLERS,
-            Commons.NO_IMAGE,
     }),
     // Quarkus is not being gratefully shutdown in Windows when running in Dev mode.
     // Reported by https://github.com/quarkusio/quarkus/issues/14647.


### PR DESCRIPTION
Fixes failures due to two upstreams issues:
Missing classes: https://github.com/quarkusio/quarkus/issues/30508
Missing builder image: https://github.com/quarkusio/quarkus/issues/30738