### PR TITLE
Update README with newer builder image introduced in Quarkus 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Example command:
 mvn clean verify -Ptestsuite -Dtest=SpecialCharsTest#diacriticsNative \
     -Dquarkus.version=1.6.0.Final -Dquarkus.platform.version=1.6.0.Final \
     -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=docker\
-    -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:22.2.0-java11
+    -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17
 ```
 
 ## Values


### PR DESCRIPTION
Update documentation regarding new builder images introduced in Quarkus 2.14

PR with the change - https://github.com/quarkusio/quarkus/pull/27997

NEW is active - https://quay.io/quarkus/ubi-quarkus-mandrel-builder-image
OLD is without update for 3 months - https://quay.io/quarkus/ubi-quarkus-native-image
