### PR TITLE
[2.13] Add QPID to ArtifactGeneratorTest on RHBQ 2.13

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -104,7 +104,7 @@ public class ArtifactGeneratorTest {
             "micrometer-registry-prometheus",
             "quarkus-openshift-client",
             "quarkus-smallrye-graphql-client",
-//            "qpid-jms",  // not part of the initial RHBQ 2.13 release
+            "qpid-jms",
     };
 
     public static final String[] supportedExtensionsSubsetSetB = new String[]{


### PR DESCRIPTION
`QPID ` is going to be part of RHBQ 2.13.7. This PR add this extension to `ArtifactGeneratorTest`