### PR TITLE
Switch to the latest Quarkus and do a little refactoring

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,10 @@ jobs:
         java: [ 11, 17 ]
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Maven 3.8.7 #TODO: https://github.com/quarkusio/quarkus/issues/31011#issuecomment-1453522507
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.8.7
       - name: Install JDK {{ matrix.java }}
         uses: actions/setup-java@v3
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>2.16.2.Final</quarkus.version>
+        <quarkus.version>2.16.3.Final</quarkus.version>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus-ide-config.version>2.5.1.Final</quarkus-ide-config.version>
         <maven.compiler.source>11</maven.compiler.source>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -675,6 +675,7 @@ public class Commands {
 
         @Override
         public void run() {
+            LOGGER.debugv("Running {0} in {1}", command, directory);
             ProcessBuilder pb = new ProcessBuilder(command);
             Map<String, String> env = pb.environment();
             env.put("PATH", System.getenv("PATH"));


### PR DESCRIPTION
QuarkusMavenPluginTest fails on the old verison, due to lack of descriptors in registry, so we need to update Quarkus version to the latest (2.16.3.Final ATM)
Also added debugging for commands being run