### PR TITLE
Move app-full-microprofile and app-jax-rs-minimal to RESTEasy Reactive

### DIFF
--- a/app-full-microprofile/pom.xml
+++ b/app-full-microprofile/pom.xml
@@ -26,7 +26,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -54,7 +54,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client</artifactId>
+            <artifactId>quarkus-rest-client-reactive</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/app-full-microprofile/threshold.properties
+++ b/app-full-microprofile/threshold.properties
@@ -1,8 +1,8 @@
-linux.jvm.time.to.first.ok.request.threshold.ms=2600
-linux.jvm.RSS.threshold.kB=550000
-linux.native.time.to.first.ok.request.threshold.ms=60
-linux.native.RSS.threshold.kB=120000
-windows.jvm.time.to.first.ok.request.threshold.ms=4500
+linux.jvm.time.to.first.ok.request.threshold.ms=2000
+linux.jvm.RSS.threshold.kB=220000
+linux.native.time.to.first.ok.request.threshold.ms=55
+linux.native.RSS.threshold.kB=80000
+windows.jvm.time.to.first.ok.request.threshold.ms=3000
 windows.jvm.RSS.threshold.kB=5000
-windows.native.time.to.first.ok.request.threshold.ms=1600
-windows.native.RSS.threshold.kB=120000
+windows.native.time.to.first.ok.request.threshold.ms=500
+windows.native.RSS.threshold.kB=5000

--- a/app-jax-rs-minimal/pom.xml
+++ b/app-jax-rs-minimal/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/app-jax-rs-minimal/threshold.properties
+++ b/app-jax-rs-minimal/threshold.properties
@@ -1,8 +1,8 @@
-linux.jvm.time.to.first.ok.request.threshold.ms=2000
-linux.jvm.RSS.threshold.kB=380000
+linux.jvm.time.to.first.ok.request.threshold.ms=1500
+linux.jvm.RSS.threshold.kB=150000
 linux.native.time.to.first.ok.request.threshold.ms=40
-linux.native.RSS.threshold.kB=90000
+linux.native.RSS.threshold.kB=60000
 windows.jvm.time.to.first.ok.request.threshold.ms=4500
 windows.jvm.RSS.threshold.kB=4800
-windows.native.time.to.first.ok.request.threshold.ms=800
-windows.native.RSS.threshold.kB=90000
+windows.native.time.to.first.ok.request.threshold.ms=500
+windows.native.RSS.threshold.kB=4800

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -64,8 +64,6 @@ public enum WhitelistLogLines {
             // comes with https://github.com/quarkusio/quarkus/pull/20182
             Pattern.compile(".*Hibernate ORM is disabled because no JPA entities were found.*"),
             Pattern.compile(".*Hibernate Reactive is disabled because no JPA entities were found.*"),
-            // https://github.com/netty/netty/issues/11020
-            Pattern.compile(".*Can not find io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider in the classpath, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS.*"),
             // comes with https://github.com/quarkusio/quarkus/pull/19969 https://github.com/quarkusio/quarkus/pull/26868 https://github.com/quarkusio/quarkus/pull/27811
             Pattern.compile(".*OIDC Server is not available.*"),
             Pattern.compile(".*localhost:6661.*"),
@@ -123,6 +121,8 @@ public enum WhitelistLogLines {
                         COMMON_SLF4J_JBOSS_LOGMANAGER_DEPENDENCY_TREE,
                         WARNING_MISSING_OBJCOPY_NATIVE,
                         WARNING_MISSING_OBJCOPY_RESULT_NATIVE,
+                        // https://github.com/netty/netty/issues/11020
+                        Pattern.compile(".*Can not find io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider in the classpath, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS.*"),
                 };
             case WINDOWS:
                 return new Pattern[] {


### PR DESCRIPTION
Move app-full-microprofile and app-jax-rs-minimal to RESTEasy Reactive

Includes change of thresholds based on experiments on my local machine (MBP 2019) and GH actions.

Fixes https://github.com/quarkus-qe/quarkus-startstop/issues/230