### PR TITLE
Cold start option for StartStopTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ exercises some rudimentary business logic of selected extensions.
 `start-stop.iterations` property - adjustment of the number of the start-stop cycles
  - append for example `-Dstart-stop.iterations=25` to the mvn command
 
+`start-stop.cold-start` property - use cold start mode to drop OS page cache entries, dentries and inodes.
+- append for example `-Dstart-stop.cold-start` to the mvn command
+
 Collect results:
 
 ```

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static io.quarkus.ts.startstop.utils.Commands.cleanTarget;
+import static io.quarkus.ts.startstop.utils.Commands.dropCaches;
 import static io.quarkus.ts.startstop.utils.Commands.getBaseDir;
 import static io.quarkus.ts.startstop.utils.Commands.getBuildCommand;
 import static io.quarkus.ts.startstop.utils.Commands.getOpenedFDs;
@@ -114,6 +115,7 @@ public class StartStopTest {
             List<Long> rssKbList = new ArrayList<>(10);
             List<Long> timeToFirstOKRequestList = new ArrayList<>(10);
             int iterations = Integer.getInteger("start-stop.iterations", 10);
+            boolean coldStart = Boolean.getBoolean("start-stop.cold-start");
             for (int i = 0; i < iterations; i++) {
                 // Run
                 LOGGER.info("Running... round " + i);
@@ -121,6 +123,10 @@ public class StartStopTest {
                 cmd = getRunCommand(mvnCmds.mvnCmds[1]);
                 appendln(whatIDidReport, appDir.getAbsolutePath());
                 appendlnSection(whatIDidReport, String.join(" ", cmd));
+                if (coldStart) {
+                    LOGGER.info("Using COLD start");
+                    dropCaches();
+                }
                 pA = runCommand(cmd, appDir, runLogA);
 
                 // Test web pages


### PR DESCRIPTION
Cold start option for StartStopTest

Fixes https://github.com/quarkus-qe/quarkus-startstop/issues/263

Difference in results is noticeable, cold start is slower than the one with warmup. Cold start is supposed to give more stable results.

Commands executed in PSI (no Linux baremetal machine available to me atm):
 - `mvn test -Ptestsuite -Dtest=StartStopTest#fullMicroProfileJVM -Dstart-stop.cold-start -Dstart-stop.iterations=50`
 - `mvn test -Ptestsuite -Dtest=StartStopTest#fullMicroProfileJVM -Dstart-stop.iterations=50`

Run 1:
```
[i.q.t.s.StartStopTest] (testRuntime) AVG timeToFirstOKRequest without min and max values: 1527
[i.q.t.s.StartStopTest] (testRuntime) AVG rssKb without min and max values: 196779

[i.q.t.s.StartStopTest] (testRuntime) AVG timeToFirstOKRequest without min and max values: 1256
[i.q.t.s.StartStopTest] (testRuntime) AVG rssKb without min and max values: 195940
```

Run 2:
```
[i.q.t.s.StartStopTest] (testRuntime) AVG timeToFirstOKRequest without min and max values: 1583
[i.q.t.s.StartStopTest] (testRuntime) AVG rssKb without min and max values: 196560

[i.q.t.s.StartStopTest] (testRuntime) AVG timeToFirstOKRequest without min and max values: 1200
[i.q.t.s.StartStopTest] (testRuntime) AVG rssKb without min and max values: 199998
```
