### PR TITLE
Adjust time.to.first.ok.request for GH Action runners

### DIFF
--- a/app-full-microprofile/threshold.properties
+++ b/app-full-microprofile/threshold.properties
@@ -1,8 +1,8 @@
 linux.jvm.time.to.first.ok.request.threshold.ms=2400
 linux.jvm.RSS.threshold.kB=220000
-linux.native.time.to.first.ok.request.threshold.ms=55
+linux.native.time.to.first.ok.request.threshold.ms=60
 linux.native.RSS.threshold.kB=80000
-windows.jvm.time.to.first.ok.request.threshold.ms=3000
+windows.jvm.time.to.first.ok.request.threshold.ms=3500
 windows.jvm.RSS.threshold.kB=5000
 windows.native.time.to.first.ok.request.threshold.ms=500
 windows.native.RSS.threshold.kB=5000


### PR DESCRIPTION
Adjust time.to.first.ok.request for GH Action runners

The original thresholds adjustment for Quarkus 3 was too close to the diff related to the environment stability.
We still have more strict thresholds thank for Quarkus 2.x series.