### PR TITLE
Disable updateTarget test on Windows due to Quarkus bug

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/QuarkusMavenPluginTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/QuarkusMavenPluginTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.IOException;
@@ -93,6 +95,7 @@ public class QuarkusMavenPluginTest {
     }
 
     @Test
+    @DisabledOnOs({OS.WINDOWS}) // https://github.com/quarkusio/quarkus/issues/33403
     public void updateTarget(TestInfo testInfo) throws IOException, InterruptedException {
         runQuarkusMavenPluginGoal(testInfo, Apps.JAX_RS_MINIMAL, "update", "quarkus:update goal is experimental");
     }


### PR DESCRIPTION
Disable `updateTarget` test on Windows due to Quarkus bug https://github.com/quarkusio/quarkus/issues/33403
