### PR TITLE
[2.13] Add MongoDB to CodeQuarkusTest native runs to verify no warnings logged

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -283,4 +283,16 @@ public class CodeQuarkusTest {
     public void supportedExtensionWithCodeStarterWorksInNative(List<CodeQuarkusExtensions> extensions, TestInfo testInfo) throws Exception {
         testRuntime(testInfo, extensions, MvnCmds.MVNW_NATIVE);
     }
+
+    @Tag("native")
+    @Test
+    public void notSupportedExtensionsWorksInNative(TestInfo testInfo) throws Exception {
+        List<CodeQuarkusExtensions> notSupportedExtensionsSubset = List.of(
+                CodeQuarkusExtensions.QUARKUS_MONGODB_CLIENT, // verifies QUARKUS-3194
+                // resteasy or spring-web extension is needed to provide index.html file
+                // content from index.html file is checked to ensure the application is up and running
+                CodeQuarkusExtensions.QUARKUS_RESTEASY_REACTIVE
+        );
+        testRuntime(testInfo, notSupportedExtensionsSubset, MvnCmds.MVNW_NATIVE);
+    }
 }


### PR DESCRIPTION
Verifies https://issues.redhat.com/browse/QUARKUS-3194. I tested it with 2.13.8.CR2, but couldn't verify failing against 2.13.7 as it is not present in code.quarkus anymore (well, I think that was the reason..), but `io.quarkus.ts.startstop.utils.Logs#checkLog` would fail if there were warnings.