### PR TITLE
Increase native threshold for GH actions

### DIFF
--- a/app-jakarta-rest-minimal/threshold.properties
+++ b/app-jakarta-rest-minimal/threshold.properties
@@ -1,6 +1,6 @@
 linux.jvm.time.to.first.ok.request.threshold.ms=1900
 linux.jvm.RSS.threshold.kB=150000
-linux.native.time.to.first.ok.request.threshold.ms=40
+linux.native.time.to.first.ok.request.threshold.ms=50
 linux.native.RSS.threshold.kB=60000
 windows.jvm.time.to.first.ok.request.threshold.ms=4500
 windows.jvm.RSS.threshold.kB=4800


### PR DESCRIPTION
Increase native `time.to.first.ok.request` threshld for `app-jakarta-rest-minimal` to make GitHub actions pass.

10 recent GH daily runs failed on exceeding this threshold with an average time of 44.5 ms.

The test has been manually ran (100 iterations) on a local environment and on a RHOS-D RHEL8 machine with no conclusive indication of increased time.

Local results:
```
3.2.1.Final:  17, 16
3.2.2.Final:  17, 18
3.2.3.Final:  18, 17
3.2.4.Final:  16, 18
```

RHOS-D results:
```
3.2.1.Final:  22, 22
3.2.2.Final:  22, 22
3.2.3.Final:  22, 22
3.2.4.Final:  22, 22
```