### PR TITLE
Fix SLF4J log error detection

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
@@ -50,7 +50,7 @@ public class Logs {
     private static final Pattern startedPatternControlSymbols = Pattern.compile(".* started in .*188m([0-9\\.]+).*", Pattern.DOTALL);
     private static final Pattern stoppedPatternControlSymbols = Pattern.compile(".* stopped in .*188m([0-9\\.]+).*", Pattern.DOTALL);
 
-    private static final Pattern warnErrorDetectionPattern = Pattern.compile("(?i:.*(ERROR|WARN|SLF4J:).*)");
+    private static final Pattern warnErrorDetectionPattern = Pattern.compile("(?i:.*(ERROR|WARN).*)|(?:.*SLF4J:.*)");
     private static final Pattern devModeError = Pattern.compile(".*Failed to run: Dev mode process did not complete successfully.*");
     private static final Pattern listeningOnDetectionPattern = Pattern.compile("(?i:.*Listening on:.*)");
     private static final Pattern devExpectedHostPattern = Pattern.compile("(?i:.*localhost:.*)");


### PR DESCRIPTION
`SLF4J:` pattern, if case-insensitive, might accidentally match artifact coordinates (e.g. `org.slf4j:slf4j-api:pom:2.0.6`). This might falsely report a benign log line.

See e.g. a failure in
https://github.com/quarkus-qe/quarkus-startstop/actions/runs/5956999432/job/16158894853.