### PR TITLE
Allow jna and jna-platform artifacts to be not productized.

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
@@ -13,6 +13,9 @@ public enum WhitelistProductBomJars {
             "com.nimbusds.oauth2-oidc-sdk",
             "com.nimbusds.content-type",
             "io.github.crac",
+            // jna and jna-platform is dependency of io.quarkus:quarkus-jdbc-mariadb
+            "net.java.dev.jna.jna",
+            "net.java.dev.jna.jna-platform",
     });
 
     public final String[] jarNames;


### PR DESCRIPTION
As the title say. Tested locally and these artifact not appearing in error output.