### PR TITLE
[3.2] Add quarkus-elasticsearch-rest-client to generator tests, TP in 3.2

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -155,6 +155,7 @@ public class ArtifactGeneratorTest {
             "websockets-client",
             "quarkus-smallrye-graphql",
             "quarkus-hibernate-search-orm-elasticsearch",
+            "quarkus-elasticsearch-rest-client",
     };
 
     public static final String[] supportedReactiveExtensionsSubsetSetA = new String[]{


### PR DESCRIPTION
Add quarkus-elasticsearch-rest-client to generator tests, TP in 3.2

backport of https://github.com/quarkus-qe/quarkus-startstop/pull/308