### PR TITLE
Bump Quarkus to 3.4.1, oidc client filter depends on RESTEasy Classic 

### DIFF
--- a/app-full-microprofile/threshold.properties
+++ b/app-full-microprofile/threshold.properties
@@ -1,7 +1,7 @@
 linux.jvm.time.to.first.ok.request.threshold.ms=2500
 linux.jvm.RSS.threshold.kB=220000
 linux.native.time.to.first.ok.request.threshold.ms=70
-linux.native.RSS.threshold.kB=80000
+linux.native.RSS.threshold.kB=83000
 windows.jvm.time.to.first.ok.request.threshold.ms=3500
 windows.jvm.RSS.threshold.kB=5000
 windows.native.time.to.first.ok.request.threshold.ms=500

--- a/app-jakarta-rest-minimal/threshold.properties
+++ b/app-jakarta-rest-minimal/threshold.properties
@@ -1,4 +1,4 @@
-linux.jvm.time.to.first.ok.request.threshold.ms=1900
+linux.jvm.time.to.first.ok.request.threshold.ms=2100
 linux.jvm.RSS.threshold.kB=150000
 linux.native.time.to.first.ok.request.threshold.ms=50
 linux.native.RSS.threshold.kB=60000

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,8 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>3.2.4.Final</quarkus.version>
+        <quarkus.version>3.4.1</quarkus.version>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus-ide-config.version>3.2.4.Final</quarkus-ide-config.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.version>3.10.1</maven.compiler.version>
@@ -137,7 +136,7 @@
                     <dependency>
                         <artifactId>quarkus-ide-config</artifactId>
                         <groupId>io.quarkus</groupId>
-                        <version>${quarkus-ide-config.version}</version>
+                        <version>${quarkus.version}</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
@@ -38,6 +38,7 @@ public enum CodeQuarkusExtensions {
 //    QUARKUS_REST_CLIENT_JAXB("quarkus-rest-client-jaxb", "REST Client JAXB", "8iY", true),
 //    QUARKUS_REST_CLIENT_JSONB("quarkus-rest-client-jsonb", "REST Client JSON-B", "Q3z", true),
 //    QUARKUS_REST_CLIENT_JACKSON("quarkus-rest-client-jackson", "REST Client Jackson", "pJg", true),
+//    QUARKUS_OIDC_CLIENT_FILTER("quarkus-oidc-client-filter", "OpenID Connect Client Filter", "T0U", true),
 
     QUARKUS_VERTX_GRAPHQL("quarkus-vertx-graphql", "Eclipse Vert.x GraphQL", "F9R", false),
     QUARKUS_HIBERNATE_VALIDATOR("quarkus-hibernate-validator", "Hibernate Validator", "YjV", true),
@@ -168,7 +169,6 @@ public enum CodeQuarkusExtensions {
     QUARKUS_KEYCLOAK_ADMIN_CLIENT_REACTIVE("quarkus-keycloak-admin-client-reactive", "Quarkus - Keycloak Admin Client - Reactive - Runtime", "ignored", false),
     QUARKUS_KEYCLOAK_AUTHORIZATION("quarkus-keycloak-authorization", "Keycloak Authorization", "2Bx", true),
     QUARKUS_OIDC_CLIENT("quarkus-oidc-client", "OpenID Connect Client", "wfZ", true),
-    QUARKUS_OIDC_CLIENT_FILTER("quarkus-oidc-client-filter", "OpenID Connect Client Filter", "T0U", true),
     QUARKUS_OIDC_TOKEN_PROPAGATION("quarkus-oidc-token-propagation", "OpenID Connect Token Propagation", "Bg9", false),
     QUARKUS_SECURITY_JPA("quarkus-security-jpa", "Security JPA", "W8w", false),
     QUARKUS_SECURITY_WEBAUTHN("quarkus-security-webauthn", "Security WebAuthn", "ignored", false),

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -143,6 +143,8 @@ public enum WhitelistLogLines {
                         WARNING_MISSING_OBJCOPY_RESULT_NATIVE,
                         // Randomly prints some SLF4J traces. Reported by https://github.com/quarkusio/quarkus/issues/16896
                         Pattern.compile(".*SLF4J:.*"),
+                        // TODO https://github.com/quarkusio/quarkus/issues/36053
+                        Pattern.compile(".*Unknown module: org.graalvm.nativeimage.*"),
                 };
             case LINUX:
             	return new Pattern[] {


### PR DESCRIPTION
 - Bump Quarkus to 3.4.1, oidc client filter depends on RESTEasy Classic 
 - Increase of the thresholds (mainly motivated by https://issues.redhat.com/browse/QUARKUS-3426)