### PR TITLE
[3.2] Increase of the thresholds, warning whitelist

### DIFF
--- a/app-full-microprofile/threshold.properties
+++ b/app-full-microprofile/threshold.properties
@@ -1,7 +1,7 @@
 linux.jvm.time.to.first.ok.request.threshold.ms=2500
 linux.jvm.RSS.threshold.kB=220000
 linux.native.time.to.first.ok.request.threshold.ms=70
-linux.native.RSS.threshold.kB=80000
+linux.native.RSS.threshold.kB=83000
 windows.jvm.time.to.first.ok.request.threshold.ms=3500
 windows.jvm.RSS.threshold.kB=5000
 windows.native.time.to.first.ok.request.threshold.ms=500

--- a/app-jakarta-rest-minimal/threshold.properties
+++ b/app-jakarta-rest-minimal/threshold.properties
@@ -1,4 +1,4 @@
-linux.jvm.time.to.first.ok.request.threshold.ms=1900
+linux.jvm.time.to.first.ok.request.threshold.ms=2100
 linux.jvm.RSS.threshold.kB=150000
 linux.native.time.to.first.ok.request.threshold.ms=50
 linux.native.RSS.threshold.kB=60000

--- a/app-jakarta-rest-minimal/threshold.properties
+++ b/app-jakarta-rest-minimal/threshold.properties
@@ -1,6 +1,6 @@
 linux.jvm.time.to.first.ok.request.threshold.ms=1900
 linux.jvm.RSS.threshold.kB=150000
-linux.native.time.to.first.ok.request.threshold.ms=40
+linux.native.time.to.first.ok.request.threshold.ms=50
 linux.native.RSS.threshold.kB=60000
 windows.jvm.time.to.first.ok.request.threshold.ms=4500
 windows.jvm.RSS.threshold.kB=4800

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -180,7 +180,7 @@ public class Commands {
     }
 
     public static String getCodeQuarkusURL() {
-        return getCodeQuarkusURL("https://code.quarkus.io");
+        return getCodeQuarkusURL("https://code.quarkus.redhat.com");
     }
 
     public static String getCodeQuarkusURL(String fallbackURL) {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -91,8 +91,8 @@ public enum WhitelistLogLines {
             Pattern.compile(".*Checksum validation failed, expected 2811ba27a71a8bda0602161ffe2f6e1429da8068 but is 36257165a0945753efb3f9d473d86c6f4c6c6f6e.*"),
             Pattern.compile(".*Could not validate integrity of download from https://repo.maven.apache.org/maven2/org/jboss/arquillian/arquillian-bom/1.7.0.Final/arquillian-bom-1.7.0.Final.pom.*"),
             Pattern.compile(".*org.eclipse.aether.util.concurrency.RunnableErrorForwarder.*"),
-            // To be able to run on Quarkus < 3.2 which does not support analytics
-            Pattern.compile(".*Unrecognized configuration key \"quarkus.analytics.disabled\" was provided.*"),
+            // To be able to run on Quarkus < 3.2 which does not support analytics (e.g. RHBQ 2.13)
+            Pattern.compile(".*Unrecognized configuration key.*quarkus.analytics.disabled.*"),
             // https://github.com/quarkusio/quarkus/issues/34626
             Pattern.compile("\\[Quarkus build analytics\\] Analytics remote config not received."),
             // Artifact org.slf4j:slf4j-parent:pom:2.0.6 is present in the local repository, but cached from a remote repository ID that is unavailable

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -95,6 +95,8 @@ public enum WhitelistLogLines {
             Pattern.compile(".*Unrecognized configuration key \"quarkus.analytics.disabled\" was provided.*"),
             // https://github.com/quarkusio/quarkus/issues/34626
             Pattern.compile("\\[Quarkus build analytics\\] Analytics remote config not received."),
+            // Artifact org.slf4j:slf4j-parent:pom:2.0.6 is present in the local repository, but cached from a remote repository ID that is unavailable
+            Pattern.compile(".*present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable.*"),
     }),
     // Quarkus is not being gratefully shutdown in Windows when running in Dev mode.
     // Reported by https://github.com/quarkusio/quarkus/issues/14647.


### PR DESCRIPTION
 - Increase of the thresholds to sync with main, mainly for QUARKUS-3426
   - https://github.com/quarkusio/quarkus/blob/3.2.6.Final/core/deployment/src/main/java/io/quarkus/deployment/pkg/NativeConfig.java#L23 uses the same image as main
 - warning whitelist for org.slf4j artifacts (env issue on GH Actions)
 - Use code.quarkus.redhat.com for CodeQuarkusTest