### PR TITLE
Whitelist BlockedThreadChecker warning for Windows

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -107,6 +107,8 @@ public enum WhitelistLogLines {
             Pattern.compile("\\[ERROR\\] *"),
             // https://github.com/quarkusio/quarkus/issues/34626
             Pattern.compile("\\[Quarkus build analytics\\] Analytics remote config not received."),
+            // GH Actions runners are sometimes slow
+            Pattern.compile("\\[io.ver.cor.imp.BlockedThreadChecker\\] (vertx-blocked-thread-checker) Thread.*has been blocked for.*"),
     });
     
     // Depending to the OS and also on the Quarkus extensions, the Native build might print some warnings about duplicate entries


### PR DESCRIPTION
Whitelist BlockedThreadChecker warning for Windows

GH Actions Windows runners are sometimes slow