### PR TITLE
Migrate from URL to URI constructor

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -11,7 +11,7 @@ import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.net.URL;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
@@ -351,7 +351,7 @@ public class Commands {
     private static String download(String downloadURL, String destinationZipFile) throws IOException {
         disableSslVerification();
         try (ReadableByteChannel readableByteChannel = Channels.newChannel(
-                new URL(downloadURL).openStream());
+                URI.create(downloadURL).toURL().openStream());
                 FileChannel fileChannel = new FileOutputStream(destinationZipFile).getChannel()) {
             fileChannel.transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
         }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WebpageTester.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WebpageTester.java
@@ -4,7 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
@@ -38,7 +38,7 @@ public class WebpageTester {
         boolean found = false;
         long foundTimestamp = -1L;
         while (now - startTime < 1000 * timeoutS) {
-            URLConnection c = new URL(url).openConnection();
+            URLConnection c = URI.create(url).toURL().openConnection();
             c.setRequestProperty("Accept", "*/*");
             c.setConnectTimeout(500);
             try (Scanner scanner = new Scanner(c.getInputStream(), StandardCharsets.UTF_8.toString())) {

--- a/testsuite/src/it/resources/JSONtoEnum.java
+++ b/testsuite/src/it/resources/JSONtoEnum.java
@@ -1,4 +1,4 @@
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 import java.util.Set;
@@ -17,7 +17,8 @@ public class JSONtoEnum {
         StringBuilder s = new StringBuilder();
         s.append("public enum CodeQuarkusExtensions {\n\n");
         Set<String> usedIds = new TreeSet<>();
-        new Scanner(new URL(args[0]).openStream(), StandardCharsets.UTF_8).useDelimiter("},\\{").tokens().forEach(x -> {
+        URI uri = URI.create(args[0]);
+        new Scanner(uri.toURL().openStream(), StandardCharsets.UTF_8).useDelimiter("},\\{").tokens().forEach(x -> {
             Matcher m = pattern.matcher(x);
             if (m.matches() && m.groupCount() == 4) {
                 String id = m.group(1);


### PR DESCRIPTION
Hi, this PR updating some deprecated method. To be prepared to JDK 21.

URL constructors was deprecated in JDK 20. Now is possible to create URL from URI.