### PR TITLE
Define test scope for dependencies used in testsuite module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,21 +37,25 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
             <version>${jboss-logging.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>${log4j.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.playwright</groupId>
             <artifactId>playwright</artifactId>
             <version>${playwright.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <profiles>


### PR DESCRIPTION
Define test scope for dependencies used in testsuite module

With Quarkus 3.4 these deps get pulled into final application classpath for app-* modules, e.g. `log4j-core`.
There were some changes ion Quarkus reflecting more stuff from the parent pom file.