### PR TITLE
Set -Xmx96m for native app runs to have upper limit when measuring RSS

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
@@ -21,7 +21,7 @@ public enum MvnCmds {
     NATIVE(new String[][]{
             Stream.concat(Stream.of("mvn", "clean", "compile", "package", "-Pnative"),
                     getQuarkusNativeProperties().stream()).toArray(String[]::new),
-            new String[]{Commands.isThisWindows ? "target\\quarkus-runner.exe" : "./target/quarkus-runner"}
+            new String[]{Commands.isThisWindows ? "target\\quarkus-runner.exe" : "./target/quarkus-runner", "-Xmx96m"}
     }),
     GENERATOR(new String[][]{
             new String[]{


### PR DESCRIPTION
Set -Xmx96m for native app runs to have upper limit when measuring RSS