### PR TITLE
Change mandrel version in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,7 +144,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: [ "mandrel-latest" ]
+        graalvm-version: [ "mandrel-23.0.1.2-Final" ]
         graalvm-java-version: [ "17" ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Change CI definition from latest mandrel version to specific version (23.0.1.2-Final) as the newest one was built only by JDK 21. This is specific for windows native.