### PR TITLE
Bump Quarkus to 3.5.0, native warnings, config-yaml warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>3.4.1</quarkus.version>
+        <quarkus.version>3.5.0</quarkus.version>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -158,6 +158,8 @@ public enum WhitelistLogLines {
                         Pattern.compile(".*SLF4J:.*"),
                         // TODO https://github.com/quarkusio/quarkus/issues/36053
                         Pattern.compile(".*Unknown module: org.graalvm.nativeimage.*"),
+                        // TODO https://github.com/quarkusio/quarkus/issues/36813
+                        Pattern.compile(".*Unrecognized configuration file .*application.yml found.*"),
                 };
             case LINUX:
             	return new Pattern[] {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -20,6 +20,9 @@ public enum WhitelistLogLines {
             Pattern.compile(".*org.eclipse.aether.util.concurrency.RunnableErrorForwarder.*"),
             // https://github.com/quarkusio/quarkus/issues/34626
             Pattern.compile("\\[Quarkus build analytics\\] Analytics remote config not received."),
+            // netty 4 which doesn't have the relevant native config in the lib. See https://github.com/netty/netty/pull/13596
+            Pattern.compile(".*Warning: Please re-evaluate whether any experimental option is required, and either remove or unlock it\\..*"),
+            Pattern.compile(".*Warning: The option '-H:ReflectionConfigurationResources=META-INF/native-image/io\\.netty/netty-transport/reflection-config\\.json' is experimental and must be enabled via.*"),
     }),
     FULL_MICROPROFILE(new Pattern[]{
             // Some artifacts names...
@@ -34,6 +37,12 @@ public enum WhitelistLogLines {
             Pattern.compile(".*RESTEASY004687: Closing a class.*CleanupAction.*"),
             // https://github.com/quarkusio/quarkus/issues/34626
             Pattern.compile("\\[Quarkus build analytics\\] Analytics remote config not received."),
+            // netty 4 which doesn't have the relevant native config in the lib. See https://github.com/netty/netty/pull/13596
+            Pattern.compile(".*Warning: Please re-evaluate whether any experimental option is required, and either remove or unlock it\\..*"),
+            Pattern.compile(".*Warning: The option '-H:ReflectionConfigurationResources=META-INF/native-image/io\\.netty/netty-transport/reflection-config\\.json' is experimental and must be enabled via.*"),
+            // native options added explicitly by FULL_MICROPROFILE application.properies
+            Pattern.compile(".*Warning: The option '-H:Log=registerResource:' is experimental and must be enabled via.*"),
+            Pattern.compile(".*Warning: The option '-H:IncludeResources=privateKey\\.pem' is experimental and must be enabled via.*"),
     }),
     GENERATED_SKELETON(new Pattern[]{
             // Harmless warning


### PR DESCRIPTION
Bump Quarkus to 3.5.0

Allow-list native warnings about experimental VM options
- `-H:ReflectionConfigurationResources`
  - Reported in `netty`: https://github.com/netty/netty/issues/13595.
  - Fixed in `netty`: https://github.com/netty/netty/pull/13596.
  - See also similar issue in https://github.com/Karm/mandrel-integration-tests/issues/190 and its workaround in https://github.com/Karm/mandrel-integration-tests/pull/203.

- `-H:Log=registerResource, -H:Log=registerResource:`
  - Added explicitly by `APP_FULL_MICROPROFILE` config.
  - Typical use case documented in Quarkus Native Reference Guide, the documentation was added in https://github.com/quarkusio/quarkus/pull/36494.
  - Allow-listed, instead of using `-H:+UnlockExperimentalVMOptions` / `-H:-UnlockExperimentalVMOptions`, to avoid errors with GraalVM / Mandrel based on Java < 21, which do not recognize this option (see https://github.com/oracle/graal/issues/7105).

Allow-list config-yaml warning on Windows
- See https://github.com/quarkusio/quarkus/issues/36813.