### PR TITLE
Add allowed warn in log containing quarkus.mongodb.native.dns.

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -95,6 +95,8 @@ public enum WhitelistLogLines {
             Pattern.compile(".*Unrecognized configuration key \"quarkus.analytics.disabled\" was provided.*"),
             // https://github.com/quarkusio/quarkus/issues/34626
             Pattern.compile("\\[Quarkus build analytics\\] Analytics remote config not received."),
+            // https://github.com/quarkusio/quarkus/issues/36775
+            Pattern.compile("(?i:.*quarkus.mongodb.native.dns.*config property is deprecated.*)"),
     }),
     // Quarkus is not being gratefully shutdown in Windows when running in Dev mode.
     // Reported by https://github.com/quarkusio/quarkus/issues/14647.


### PR DESCRIPTION
This fixes daily, but property was deprecated long ago, is still injected by Quarkus it self so looking what the cause and why it't happening only with 3.5. Link to Quarkus commit [https://github.com/quarkusio/quarkus/commit/c4d6bdcea1d14c4fd2a66e3ea48778e832ca0fe7](https://github.com/quarkusio/quarkus/commit/c4d6bdcea1d14c4fd2a66e3ea48778e832ca0fe7) 