### PR TITLE
Move Java baseline to 17

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v3
       - name: Install JDK {{ matrix.java }}
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 17, 21 ]
     steps:
       - uses: actions/checkout@v3
       - name: Install JDK {{ matrix.java }}
@@ -56,7 +56,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          java: [ 11 ]
+          java: [ 17 ]
       steps:
         - uses: actions/checkout@v3
         - name: Install JDK {{ matrix.java }}
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 17, 21 ]
     steps:
       - uses: actions/checkout@v3
       - name: Install JDK {{ matrix.java }}
@@ -112,7 +112,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 17, 21 ]
     steps:
       - uses: actions/checkout@v3
       - name: Install JDK {{ matrix.java }}
@@ -143,9 +143,9 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        java: [ 11 ]
-        graalvm-version: [ "mandrel-23.0.1.2-Final" ]
-        graalvm-java-version: [ "17" ]
+        java: [ 17 ]
+        graalvm-version: [ "mandrel-latest" ]
+        graalvm-java-version: [ "21" ]
     steps:
       - uses: actions/checkout@v3
       - name: Install JDK {{ matrix.java }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Generates, starts, tests, stops small Quarkus applications and measures time and
 
 ## Prerequisites
 
-The TS expects you run Apache Maven 3.6.3+, Java 11+ and have ```ps``` program available on your Linux/Mac and ```wmic``` (by default present) on your Windows system.
+The TS expects you run Apache Maven 3.6.3+, Java 17+ and have ```ps``` program available on your Linux/Mac and ```wmic``` (by default present) on your Windows system.
 Native image build requires GraalVM with Native image toolchain installed. Refer to [Building Native Image Guide](https://quarkus.io/guides/building-native-image) for details. 
 
 ## Branches
@@ -107,7 +107,7 @@ Build and run logs are archived and checked for errors, see:
 **/io.quarkus.ts.startstop.ArtifactGeneratorTest/manyExtensions/warmup-dev-run.log
 ```
 
-Measurements example, e.g. Windows and OpenJDK 11 J9:
+Measurements example, e.g. Windows and OpenJDK 17 J9:
 
 ```
 λ type testsuite\target\archived-logs\io.quarkus.ts.startstop.ArtifactGeneratorTest\measurements.csv
@@ -118,7 +118,7 @@ GENERATED_SKELETON,GENERATOR,3766,37064,8859,18249,1172,4240,81
 e.g. it took 3.766s to generate the skeleton project, it took 37.064s to build and start the Dev mode and it
 took 8.859s to do the live reload and get the expected response to a request.
 
-Linux and OpenJDK 11 HotSpot:
+Linux and OpenJDK 17 HotSpot:
 
 ```
 App,Mode,buildTimeMs,timeToFirstOKRequestMs,timeToReloadMs,startedInMs,stoppedInMs,RSSKb,FDs

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <properties>
         <quarkus.version>3.5.0</quarkus.version>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.version>3.10.1</maven.compiler.version>
         <maven.surefire.version>2.22.2</maven.surefire.version>
         <maven.failsafe.version>2.22.2</maven.failsafe.version>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -93,7 +93,7 @@ public class CodeQuarkusTest {
             appendln(whatIDidReport, "# " + cn + ", " + mn);
             appendln(whatIDidReport, (new Date()).toString());
             LOGGER.info("Downloading...");
-            appendln(whatIDidReport, "Download URL: " + download(extensions, zipFile, 11));
+            appendln(whatIDidReport, "Download URL: " + download(extensions, zipFile, 17));
             LOGGER.info("Unzipping...");
             unzipLog = unzip(zipFile, GEN_BASE_DIR);
             if (StringUtils.isBlank(System.getProperty("gh.actions"))) {
@@ -219,7 +219,7 @@ public class CodeQuarkusTest {
     }
 
     @Test
-    public void java17BasedProject(TestInfo testInfo) throws Exception {
+    public void java21BasedProject(TestInfo testInfo) throws Exception {
         StringBuilder whatIDidReport = new StringBuilder();
         String cn = testInfo.getTestClass().get().getCanonicalName();
         String mn = testInfo.getTestMethod().get().getName();
@@ -230,12 +230,12 @@ public class CodeQuarkusTest {
             appendln(whatIDidReport, "# " + cn + ", " + mn);
             appendln(whatIDidReport, (new Date()).toString());
             LOGGER.info("Downloading...");
-            appendln(whatIDidReport, "Download URL: " + download(List.of(CodeQuarkusExtensions.QUARKUS_RESTEASY_REACTIVE), zipFile, 17));
+            appendln(whatIDidReport, "Download URL: " + download(List.of(CodeQuarkusExtensions.QUARKUS_RESTEASY_REACTIVE), zipFile, 21));
             LOGGER.info("Unzipping...");
             unzip(zipFile, GEN_BASE_DIR);
 
             String pom = Files.readString(Paths.get(GEN_BASE_DIR + File.separator + "code-with-quarkus" + File.separator + "pom.xml"));
-            assertTrue(pom.contains("<maven.compiler.release>17"), "Downloaded app doesn't have pom.xml file Java 17 based");
+            assertTrue(pom.contains("<maven.compiler.release>21"), "Downloaded app doesn't have pom.xml file Java 21 based");
 
         } finally {
             writeReport(cn, mn, whatIDidReport.toString());
@@ -244,7 +244,7 @@ public class CodeQuarkusTest {
     }
 
     /*
-     * Similar to java17BasedProject test, but not forcing concrete java version
+     * Similar to java21BasedProject test, but not forcing concrete java version
      */
     @Test
     public void defaultJavaBasedProject(TestInfo testInfo) throws Exception {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -337,7 +337,7 @@ public class Commands {
      *
      * @param extensions         collection of extension codes, @See {@link io.quarkus.ts.startstop.utils.CodeQuarkusExtensions}
      * @param destinationZipFile path where the zip file will be written
-     * @param javaVersion        Java version used in generated project (11 or 17)
+     * @param javaVersion        Java version used in generated project (17 or 21)
      * @return the actual URL used for audit and logging purposes
      * @throws IOException
      */

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -106,6 +106,8 @@ public enum WhitelistLogLines {
             Pattern.compile("\\[Quarkus build analytics\\] Analytics remote config not received."),
             // https://github.com/quarkusio/quarkus/issues/36775
             Pattern.compile("(?i:.*quarkus.mongodb.native.dns.*config property is deprecated.*)"),
+            // https://github.com/quarkusio/quarkus/issues/37532
+            Pattern.compile(".*Annotation processing is enabled because one or more processors were found.*")
     }),
     // Quarkus is not being gratefully shutdown in Windows when running in Dev mode.
     // Reported by https://github.com/quarkusio/quarkus/issues/14647.


### PR DESCRIPTION
Quarkus changed, we need to get Quarkus Startstop ready for 3.7. See also https://github.com/quarkus-qe/quarkus-test-suite/pull/1556.