### PR TITLE
Whitelist SmallRye Reactive Messaging split package usage warning logs

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -102,7 +102,9 @@ public enum WhitelistLogLines {
             // https://github.com/quarkusio/quarkus/issues/36775
             Pattern.compile("(?i:.*quarkus.mongodb.native.dns.*config property is deprecated.*)"),
             // https://github.com/quarkusio/quarkus/issues/37532
-            Pattern.compile(".*Annotation processing is enabled because one or more processors were found.*")
+            Pattern.compile(".*Annotation processing is enabled because one or more processors were found.*"),
+            // https://github.com/quarkusio/quarkus/issues/38711
+            Pattern.compile(".*SplitPackageProcessor.*Following packages were detected in multiple archives.*")
     }),
     // Quarkus is not being gratefully shutdown in Windows when running in Dev mode.
     // Reported by https://github.com/quarkusio/quarkus/issues/14647.


### PR DESCRIPTION
Daily build fails over:
```
[ERROR] Failures: 
[ERROR]   CodeQuarkusTest.supportedExtensionsSubsetB:185->testRuntime:155 MVNW_DEV log should not contain error or warning lines that are not whitelisted. See testsuite/target/archived-logs/io.quarkus.ts.startstop.CodeQuarkusTest/supportedExtensionsSubsetB/dev-run.log and check these offending lines: 
2024-02-09 15:39:07,725 WARN  [io.qua.arc.dep.SplitPackageProcessor] (build-46) Detected a split package usage which is considered a bad practice and should be avoided. Following packages were detected in multiple archives:  ==> expected: <true> but was: <false>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```
which in logs you can see is SR RM, I've opened issue https://github.com/quarkusio/quarkus/issues/38711
```
2024-02-08 22:31:15,062 WARN  [io.qua.arc.dep.SplitPackageProcessor] (build-34) Detected a split package usage which is considered a bad practice and should be avoided. Following packages were detected in multiple archives: 
- "io.smallrye.reactive.messaging.health" found in [io.smallrye.reactive:smallrye-reactive-messaging-api::jar, io.smallrye.reactive:smallrye-reactive-messaging-health::jar]
```

This PR is whitelisting all split package warnings, for sadly everything after `in multiple archives:` is in different line.