### PR TITLE
Disable Code Quarkus site Java 11 check till fixed upstream

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -107,7 +107,8 @@ public class CodeQuarkusSiteTest {
         assertTrue(javaVersionSelect.count() == 1, "Element: " + elementJavaVersionSelectByXpath + " is missing!");
 
         String javaVersionText = javaVersionSelect.textContent();
-        assertTrue(javaVersionText.contains("11"), "Java 11 is missing in java version select! javaVersionText: " + javaVersionText);
+        // TODO: enable Java 11 check when https://github.com/quarkusio/quarkus/issues/38732 is released
+        // assertTrue(javaVersionText.contains("11"), "Java 11 is missing in java version select! javaVersionText: " + javaVersionText);
         assertTrue(javaVersionText.contains("17"), "Java 17 is missing in java version select! javaVersionText: " + javaVersionText);
     }
 


### PR DESCRIPTION
https://code.quarkus.redhat.com/ only offers Java 17. We need to wait till https://github.com/quarkusio/quarkus/issues/38732 is fixed in a released Quarkus version.