### PR TITLE
Fix detection of redhat version

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -69,7 +69,7 @@ public class Commands {
     private static final String QUARKUS_PLATFORM_GROUP_ID = "com.redhat.quarkus.platform";
     private static final String QUARKUS_UPSTREAM_GROUP_ID = "io.quarkus.platform";
     private static final String QUARKUS_CORE_GROUP_ID = "io.quarkus";
-    private static final String REDHAT_VERSION_TAG = "-redhat-";
+    private static final String REDHAT_VERSION_TAG = "redhat-";
     private static final String QUARKUS_MAIN_VERSION = "999-SNAPSHOT";
 
     public static String mvnw() {


### PR DESCRIPTION
String '-redhat-' can detect old format (3.2.11.Final-redhat-00001) but fails on the new one (3.8.3.redhat-00002)