### PR TITLE
Fix/3.8.cr2

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -221,7 +221,7 @@ public class CodeQuarkusTest {
     }
 
     @Test
-    public void java21BasedProject(TestInfo testInfo) throws Exception {
+    public void java17BasedProject(TestInfo testInfo) throws Exception {
         StringBuilder whatIDidReport = new StringBuilder();
         String cn = testInfo.getTestClass().get().getCanonicalName();
         String mn = testInfo.getTestMethod().get().getName();
@@ -232,12 +232,12 @@ public class CodeQuarkusTest {
             appendln(whatIDidReport, "# " + cn + ", " + mn);
             appendln(whatIDidReport, (new Date()).toString());
             LOGGER.info("Downloading...");
-            appendln(whatIDidReport, "Download URL: " + download(List.of(CodeQuarkusExtensions.QUARKUS_RESTEASY_REACTIVE), zipFile, 21));
+            appendln(whatIDidReport, "Download URL: " + download(List.of(CodeQuarkusExtensions.QUARKUS_RESTEASY_REACTIVE), zipFile, 17));
             LOGGER.info("Unzipping...");
             unzip(zipFile, GEN_BASE_DIR);
 
             String pom = Files.readString(Paths.get(GEN_BASE_DIR + File.separator + "code-with-quarkus" + File.separator + "pom.xml"));
-            assertTrue(pom.contains("<maven.compiler.release>21"), "Downloaded app doesn't have pom.xml file Java 21 based");
+            assertTrue(pom.contains("<maven.compiler.release>17"), "Downloaded app doesn't have Java 17 as a default version in pom.xml");
 
         } finally {
             writeReport(cn, mn, whatIDidReport.toString());
@@ -265,7 +265,7 @@ public class CodeQuarkusTest {
             unzip(zipFile, GEN_BASE_DIR);
 
             String pom = Files.readString(Paths.get(GEN_BASE_DIR + File.separator + "code-with-quarkus" + File.separator + "pom.xml"));
-            assertTrue(pom.contains("<maven.compiler.release>17"), "Downloaded app doesn't have pom.xml file Java 17 based, Java 17 is the default");
+            assertTrue(pom.contains("<maven.compiler.release>21"), "Downloaded app doesn't have Java 21 as a default in pom.xml");
 
         } finally {
             writeReport(cn, mn, whatIDidReport.toString());

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
@@ -16,6 +16,9 @@ public enum WhitelistProductBomJars {
             // jna and jna-platform is dependency of io.quarkus:quarkus-jdbc-mariadb
             "net.java.dev.jna.jna",
             "net.java.dev.jna.jna-platform",
+            // https://issues.redhat.com/browse/QUARKUS-4078
+            "org.jetbrains.kotlin.kotlin-stdlib",
+            "org.jetbrains.kotlinx.kotlinx-metadata-jvm"
     });
 
     public final String[] jarNames;


### PR DESCRIPTION
1. Backports https://github.com/quarkus-qe/quarkus-startstop/pull/360
2. Allows for kotlin libraries to not be productised