### PR TITLE
Change the search for platform version

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -49,7 +49,7 @@ public class CodeQuarkusSiteTest {
     public static final String elementStreamPickerByXpath= "//div[@class=\"stream-picker dropdown\"]";
     public static final String elementStreamItemsByXpath= "//div[@class=\"dropdown-item\"]";
     public static final String elementSupportedFlagByXpath = "//div[@class=\"extension-tag redhat-support-supported dropdown-toggle\"]";
-    public static final String elementQuarkusPlatformVersionByXpath = "//div[@class=\"quarkus-stream\"]";
+    public static final String elementQuarkusPlatformVersionByXpath = "//div[contains(@class, 'quarkus-stream')]";
 
     private BrowserContext browserContext; // Operates in incognito mode
 


### PR DESCRIPTION
Since 3.8.3, code.quarkus may contain version number in HTML elements of different classes: `quarkus-stream`, `quarkus-stream redhat` and so on. To adapt to that, we need to change our search conditions. See https://issues.redhat.com/browse/QUARKUS-4187 for details