### PR TITLE
Resolve java home dir from system properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ index 0c02537..6278605 100755
  public enum MvnCmds {
      JVM(new String[][]{
              new String[]{"mvn", "clean", "compile", "quarkus:build", "-Dquarkus.package.output-name=quarkus"},
--            new String[]{"java", "-jar", "target/quarkus-runner.jar"}
-+            new String[]{"java",
+-            new String[]{Commands.JAVA_BIN, "-jar", "target/quarkus-runner.jar"}
++            new String[]{Commands.JAVA_BIN,
 +                    "-agentpath:/var/lib/jenkins/async-profiler-1.8.1-linux-x64/build/libasyncProfiler.so=start,event=cpu,file=/tmp/startup-cpu-profile.svg,interval=1000000,width=1600,simple",
 +                    "-jar", "target/quarkus-runner.jar"}
      }),

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -6,7 +6,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -34,7 +33,6 @@ import java.util.Objects;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -71,6 +69,8 @@ public class Commands {
     private static final String QUARKUS_CORE_GROUP_ID = "io.quarkus";
     private static final String REDHAT_VERSION_TAG = "redhat-";
     private static final String QUARKUS_MAIN_VERSION = "999-SNAPSHOT";
+    public static final String JAVA_BIN = String.format("%s/bin/java", System.getProperty("java.home"));
+
 
     public static String mvnw() {
         return Commands.isThisWindows ? "mvnw.cmd" : "./mvnw";

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
@@ -13,7 +13,7 @@ import static io.quarkus.ts.startstop.utils.Commands.getQuarkusVersion;
 public enum MvnCmds {
     JVM(new String[][]{
             new String[]{"mvn", "clean", "dependency:tree", "compile", "quarkus:build", "-Dquarkus.package.output-name=quarkus"},
-            new String[]{"java", "-jar", "target/quarkus-app/quarkus-run.jar"}
+            new String[]{Commands.JAVA_BIN, "-jar", "target/quarkus-app/quarkus-run.jar"}
     }),
     DEV(new String[][]{
             new String[]{"mvn", "clean", "quarkus:dev", "-Dmaven.repo.local=" + getLocalMavenRepoDir(), "-Dquarkus.analytics.disabled=true"}
@@ -39,7 +39,7 @@ public enum MvnCmds {
     }),
     MVNW_JVM(new String[][]{
         new String[]{Commands.mvnw(), "clean", "dependency:tree", "compile", "quarkus:build", "-Dquarkus.package.output-name=quarkus"},
-        new String[]{"java", "-jar", "target/quarkus-app/quarkus-run.jar"}
+        new String[]{Commands.JAVA_BIN, "-jar", "target/quarkus-app/quarkus-run.jar"}
     }),
     MVNW_NATIVE(new String[][]{
         Stream.concat(Stream.of(Commands.mvnw(), "clean", "dependency:tree", "compile", "package", "-Pnative", "-Dquarkus.package.output-name=quarkus"),


### PR DESCRIPTION
Maven inspects the `$JAVA_HOME` environment variable to determine which java binary to use to build a project. 

The `MvnCmds` enum commands are used to fork new processes for testing, by calling `java` in the forked process. This resolves the java binary from the environment `$PATH`.  If these differ, the tests can fail as a newer java version could be specified in `$JAVA_HOME` when the mvn process is started, and an older java version could be used the test application(s)

This PR resolves the jara binary that is being used to build the applications and uses the same java binary to start the applications in a forked process. 

This ensures that the JDK that was used to build the test application(s) is the same JDK used to run them

**Please note**: I have not been able to test this change as when I try to run with the following options `mvn clean verify -Ptestsuite-community-no-native -DincludeTags=startstop`, it fails with errors