### PR TITLE
[3.2] Bump Quarkus to 3.2.12.Final and add some backports

### DIFF
--- a/app-generated-skeleton/index.html
+++ b/app-generated-skeleton/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Landing Page</title>
+</head>
+<body>
+<main>
+    <h1>Congratulations! You are on a landing page.</h1>
+</main>
+</body>
+</html>

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>3.2.11.Final</quarkus.version>
+        <quarkus.version>3.2.12.Final</quarkus.version>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus-ide-config.version>3.2.11.Final</quarkus-ide-config.version>
+        <quarkus-ide-config.version>3.2.12.Final</quarkus-ide-config.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.version>3.10.1</maven.compiler.version>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
@@ -30,6 +30,7 @@ import static io.quarkus.ts.startstop.ArtifactGeneratorTest.supportedReactiveExt
 import static io.quarkus.ts.startstop.utils.Commands.adjustPrettyPrintForJsonLogging;
 import static io.quarkus.ts.startstop.utils.Commands.cleanDirOrFile;
 import static io.quarkus.ts.startstop.utils.Commands.confAppPropsForSkeleton;
+import static io.quarkus.ts.startstop.utils.Commands.confIndexPageForSkeleton;
 import static io.quarkus.ts.startstop.utils.Commands.dropEntityAnnotations;
 import static io.quarkus.ts.startstop.utils.Commands.getArtifactGeneBaseDir;
 import static io.quarkus.ts.startstop.utils.Commands.getBuildCommand;
@@ -101,6 +102,7 @@ public class ArtifactGeneratorBOMTest {
 
             // Config, see app-generated-skeleton/README.md
             confAppPropsForSkeleton(appDir.getAbsolutePath());
+            confIndexPageForSkeleton(appDir.getAbsolutePath());
             adjustPrettyPrintForJsonLogging(appDir.getAbsolutePath());
             dropEntityAnnotations(appDir.getAbsolutePath());
             if (StringUtils.isBlank(System.getProperty("gh.actions"))) {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -3,6 +3,7 @@ package io.quarkus.ts.startstop;
 import static io.quarkus.ts.startstop.utils.Commands.adjustPrettyPrintForJsonLogging;
 import static io.quarkus.ts.startstop.utils.Commands.cleanDirOrFile;
 import static io.quarkus.ts.startstop.utils.Commands.confAppPropsForSkeleton;
+import static io.quarkus.ts.startstop.utils.Commands.confIndexPageForSkeleton;
 import static io.quarkus.ts.startstop.utils.Commands.copyFileForSkeleton;
 import static io.quarkus.ts.startstop.utils.Commands.dropEntityAnnotations;
 import static io.quarkus.ts.startstop.utils.Commands.getArtifactGeneBaseDir;
@@ -291,6 +292,7 @@ public class ArtifactGeneratorTest {
 
             // Config, see app-generated-skeleton/README.md
             confAppPropsForSkeleton(appDir.getAbsolutePath());
+            confIndexPageForSkeleton(appDir.getAbsolutePath());
             adjustPrettyPrintForJsonLogging(appDir.getAbsolutePath());
             dropEntityAnnotations(appDir.getAbsolutePath());
             if (StringUtils.isBlank(System.getProperty("gh.actions"))) {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 
 import static io.quarkus.ts.startstop.utils.Commands.adjustPrettyPrintForJsonLogging;
 import static io.quarkus.ts.startstop.utils.Commands.cleanDirOrFile;
+import static io.quarkus.ts.startstop.utils.Commands.confIndexPageForSkeleton;
 import static io.quarkus.ts.startstop.utils.Commands.disableDevServices;
 import static io.quarkus.ts.startstop.utils.Commands.download;
 import static io.quarkus.ts.startstop.utils.Commands.dropEntityAnnotations;
@@ -100,6 +101,7 @@ public class CodeQuarkusTest {
                 LOGGER.info("Removing repositories and pluginRepositories from pom.xml ...");
                 removeRepositoriesAndPluginRepositories(appDir + File.separator + "pom.xml");
             }
+            confIndexPageForSkeleton(appDir.getAbsolutePath());
             adjustPrettyPrintForJsonLogging(appDir.getAbsolutePath());
             disableDevServices(appDir.getAbsolutePath());
             dropEntityAnnotations(appDir.getAbsolutePath());

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -423,6 +423,14 @@ public class Commands {
         copyFileForSkeleton("application.properties", Paths.get(appDir + File.separator + appRelativePath));
     }
 
+    public static void confIndexPageForSkeleton(String appDir) throws IOException {
+        final String appRelativePath =
+                "src" + File.separator + "main" + File.separator + "resources" + File.separator + "META-INF" + File.separator + "resources";
+        final String appIndexRelativePath = appRelativePath + File.separator + "index.html";
+        Files.createDirectories(Paths.get(appDir + File.separator + appRelativePath));
+        copyFileForSkeleton("index.html", Paths.get(appDir + File.separator + appIndexRelativePath));
+    }
+
     public static void copyFileForSkeleton(String skeletonFileRelativePath, Path destPath)
             throws IOException {
         final String srcPath = BASE_DIR + File.separator + Apps.GENERATED_SKELETON.dir + File.separator + skeletonFileRelativePath;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/URLContent.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/URLContent.java
@@ -22,7 +22,7 @@ public enum URLContent {
             new String[]{"http://localhost:8080/data/client/test/parameterValue=xxx", "Processed parameter value 'parameterValue=xxx'"}
     }),
     GENERATED_SKELETON(new String[][]{
-            new String[]{"http://localhost:8080", "Congratulations"},
+            new String[]{"http://localhost:8080", "Congratulations! You are on a landing page."},
             new String[]{"http://localhost:8080/hello", "Bye RESTEasy"},
             new String[]{"http://localhost:8080/hello-added", "Hello added"},
             new String[]{"http://localhost:8080/hello", "Bye from RESTEasy Reactive"},


### PR DESCRIPTION
Updating Quarkus and Quarkus config version to 3.2.12.Final

Backport the code.quarkus.io not generating index.html

Also backport `Run plugin tests in separate directories` causing errors as it was update skeleton to 3.9 which have different rest artifact name