### PR TITLE
[3.8] Revert "Allow kotlin libraries not to be productised for 3.8"

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
@@ -16,9 +16,6 @@ public enum WhitelistProductBomJars {
             // jna and jna-platform is dependency of io.quarkus:quarkus-jdbc-mariadb
             "net.java.dev.jna.jna",
             "net.java.dev.jna.jna-platform",
-            // https://issues.redhat.com/browse/QUARKUS-4078
-            "org.jetbrains.kotlin.kotlin-stdlib",
-            "org.jetbrains.kotlinx.kotlinx-metadata-jvm"
     });
 
     public final String[] jarNames;


### PR DESCRIPTION
This reverts commit 8465e92d93ab8080415df84c2dce3df6f95f0dad.

See https://issues.redhat.com/browse/QUARKUS-4289 fro details