### PR TITLE
[3.8] RHBQ 3.8 changes

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -136,7 +136,7 @@ public class CodeQuarkusSiteTest {
         String quarkusPlatformVersion = getQuarkusVersion();
         Assumptions.assumeTrue(quarkusPlatformVersion.contains("redhat"));
 
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl + "?S=com.redhat.quarkus.platform%3A3.8", 60);
         LOGGER.info("Trying to find element: " + elementQuarkusPlatformVersionByXpath);
         String quarkusPlatformVersionFromWeb = page.locator(elementQuarkusPlatformVersionByXpath).elementHandle().getAttribute("title");
 

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -184,7 +184,7 @@ public class Commands {
     }
 
     public static String getCodeQuarkusURL() {
-        return getCodeQuarkusURL("https://code.quarkus.io");
+        return getCodeQuarkusURL("https://code.quarkus.redhat.com");
     }
 
     public static String getCodeQuarkusURL(String fallbackURL) {


### PR DESCRIPTION
 -  Use code.quarkus.redhat.com for CodeQuarkusTest 
 -  Run validateQuarkusVersionMatch against 3.8 stream 