### PR TITLE
AsyncProfiler 3.0 support and javac warning

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/AsyncProfiler.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/AsyncProfiler.java
@@ -1,0 +1,146 @@
+package io.quarkus.ts.startstop.utils;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.logging.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static io.quarkus.ts.startstop.StartStopTest.BASE_DIR;
+import static io.quarkus.ts.startstop.utils.Commands.isThisLinux;
+import static io.quarkus.ts.startstop.utils.Commands.runCommand;
+import static io.quarkus.ts.startstop.utils.Logs.archiveLog;
+
+public final class AsyncProfiler {
+
+    private static final Logger LOGGER = Logger.getLogger(AsyncProfiler.class.getName());
+    private final File lib;
+    private final File exe;
+    private final String agentConfig;
+
+    private AsyncProfiler(File lib, File exe, String agentConfig) {
+        this.lib = lib;
+        this.exe = exe;
+        this.agentConfig = agentConfig;
+    }
+
+    public List<String> createJavaProfiledRunCommand(String[] baseCommand) {
+        boolean javaCmd = false;
+        List<String> runCmd = new ArrayList<>(baseCommand.length + 1);
+        for (String cmdPart : baseCommand) {
+            runCmd.add(cmdPart);
+            if (cmdPart.equals(Commands.JAVA_BIN)) {
+                javaCmd = true;
+                runCmd.add("-agentpath:" + lib.getAbsolutePath() + "=" + agentConfig);
+            }
+        }
+        if (!javaCmd) {
+            throw new IllegalArgumentException("No java command found in the base command");
+        }
+        return Collections.unmodifiableList(runCmd);
+    }
+
+    public void stopProfing(File appDir, MvnCmds mvnCmds, Process app, int id) {
+        try {
+            File profilingOutputDir = getProfilingOutputDir(appDir);
+            if (!Files.exists(profilingOutputDir.toPath())) {
+                Files.createDirectory(profilingOutputDir.toPath());
+            }
+            String profilerOutputFullPath = profilingOutputDir.getAbsolutePath() + File.separator + mvnCmds.name().toLowerCase() + "-run-" + id + ".html";
+            LOGGER.infof("Attaching profiler agent to the JVM process. Output HTML: %s", profilerOutputFullPath);
+            LOGGER.info("Stopping the profiler agent...");
+            Process stopProfiling = runCommand(List.of(exe.getAbsolutePath(), "stop", "-f", profilerOutputFullPath, "" + app.pid()), appDir, null);
+            long initiateStopAt = stopProfiling.info().startInstant().get().toEpochMilli();
+            if (stopProfiling.isAlive() && !stopProfiling.waitFor(10, TimeUnit.SECONDS)) {
+                LOGGER.warn("Profiler agent did not stop in 10 seconds");
+            } else {
+                final long stoppingDuration = System.currentTimeMillis() - initiateStopAt;
+                final long cpuTimeMs = app.info().totalCpuDuration().get().toMillis();
+                LOGGER.infof("CPU time of the profiled process: %d ms", cpuTimeMs);
+                LOGGER.infof("Stopping the profiler agent tooks %d ms", stoppingDuration);
+                if (stopProfiling.exitValue() != 0) {
+                    LOGGER.warn("Profiler agent did not stop successfully: exitValue = " + stopProfiling.exitValue());
+                }
+            }
+        } catch (Throwable t) {
+            LOGGER.error("Failed to stop the profiler agent", t);
+            throw new RuntimeException(t);
+        }
+    }
+
+    public void archiveProfilingResults(String cn, String mn, File appDir) {
+        File profilingOutputDir = getProfilingOutputDir(appDir);
+        if (!Files.exists(profilingOutputDir.toPath())) {
+            return;
+        }
+        try {
+            archiveLog(cn, mn, profilingOutputDir);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void cleanProfilingResults(Apps app) {
+        String profiling = BASE_DIR + File.separator + app.dir + File.separator + "profiling";
+        Commands.cleanDirOrFile(profiling);
+    }
+
+    private static File getProfilingOutputDir(File appDir) {
+        File profilingOutputDir = new File(appDir.getAbsolutePath() + File.separator + "profiling");
+        return profilingOutputDir;
+    }
+
+    public static Optional<AsyncProfiler> create() {
+        if (!isThisLinux) {
+            return Optional.empty();
+        }
+        String apDirFullPath = getAsyncProfilerDir();
+        if (apDirFullPath == null) {
+            return Optional.empty();
+        }
+        File apDir = new File(apDirFullPath);
+        if (!apDir.isDirectory()) {
+            throw new IllegalArgumentException(apDirFullPath + " is not a directory");
+        }
+        // check if the bin/asProf and lib/libasyncProfiler.so are present
+        File asProf = new File(apDir, "bin" + File.separator + "asprof");
+        if (!asProf.exists() || !asProf.canExecute() || !asProf.isFile()) {
+            throw new IllegalStateException("asprof executable not found or not executable on : " + asProf.getAbsolutePath());
+        }
+        File soLib = new File(apDir, "lib" + File.separator + "libasyncProfiler.so");
+        if (!soLib.exists() || !soLib.isFile()) {
+            throw new IllegalStateException("libasyncProfiler.so not found on : " + soLib.getAbsolutePath());
+        }
+        return Optional.of(new AsyncProfiler(soLib, asProf, getAsyncProfilerAgentConfig()));
+    }
+
+    private static String getAsyncProfilerAgentConfig() {
+        String apConfig = System.getenv().get("ASYNC_PROFILER_AGENT_CONFIG");
+        if (StringUtils.isNotBlank(apConfig)) {
+            return apConfig;
+        }
+        apConfig = System.getProperty("ASYNC_PROFILER_AGENT_CONFIG");
+        if (StringUtils.isNotBlank(apConfig)) {
+            return apConfig;
+        }
+        return "start,event=cpu,interval=1000000";
+    }
+
+    private static String getAsyncProfilerDir() {
+        String apLibDir = System.getenv().get("ASYNC_PROFILER_DIR");
+        if (StringUtils.isNotBlank(apLibDir)) {
+            return apLibDir;
+        }
+        apLibDir = System.getProperty("ASYNC_PROFILER_DIR");
+        if (StringUtils.isNotBlank(apLibDir)) {
+            return apLibDir;
+        }
+        return null;
+    }
+}

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -494,7 +494,9 @@ public class Commands {
         envA.put("PATH", System.getenv("PATH"));
         pa.directory(directory);
         pa.redirectErrorStream(true);
-        pa.redirectOutput(ProcessBuilder.Redirect.to(logFile));
+        if (logFile != null) {
+            pa.redirectOutput(ProcessBuilder.Redirect.to(logFile));
+        }
         Process pA = null;
         try {
             pA = pa.start();

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
@@ -206,7 +206,20 @@ public class Logs {
         Path destDir = getLogsDir(testClass, testMethod);
         Files.createDirectories(destDir);
         String filename = log.getName();
-        Files.copy(log.toPath(), Paths.get(destDir.toString(), filename), REPLACE_EXISTING);
+
+        if (log.isDirectory()) {
+            // copy all files in the directory to the destination directory
+            File[] files = log.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    if (!file.isDirectory()) {
+                        Files.copy(file.toPath(), Paths.get(destDir.toString(), file.getName()), REPLACE_EXISTING);
+                    }
+                }
+            }
+        } else {
+            Files.copy(log.toPath(), Paths.get(destDir.toString(), filename), REPLACE_EXISTING);
+        }
     }
 
     public static void writeReport(String testClass, String testMethod, String text) throws IOException {

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WebpageTester.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WebpageTester.java
@@ -4,10 +4,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
+import java.util.concurrent.locks.LockSupport;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -41,7 +43,8 @@ public class WebpageTester {
             URLConnection c = URI.create(url).toURL().openConnection();
             c.setRequestProperty("Accept", "*/*");
             c.setConnectTimeout(500);
-            try (Scanner scanner = new Scanner(c.getInputStream(), StandardCharsets.UTF_8.toString())) {
+            try (InputStream in = c.getInputStream();
+                 Scanner scanner = new Scanner(in, StandardCharsets.UTF_8.toString())) {
                 scanner.useDelimiter("\\A");
                 webPage = scanner.hasNext() ? scanner.next() : "";
             } catch (Exception e) {
@@ -57,7 +60,7 @@ public class WebpageTester {
             if (!measureTime) {
                 Thread.sleep(500);
             } else {
-                Thread.sleep(0, 100000);
+                LockSupport.parkNanos(100000);
             }
             now = System.currentTimeMillis();
         }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -129,6 +129,7 @@ public enum WhitelistLogLines {
     private static final Pattern WARNING_MISSING_OBJCOPY_NATIVE = Pattern.compile(".*objcopy executable not found in PATH.*");
     private static final Pattern WARNING_MISSING_OBJCOPY_RESULT_NATIVE = Pattern.compile(".*That also means that resulting native executable is larger as it embeds the debug symbols..*");
     private static final Pattern XML_APIS_RELOCATED = Pattern.compile(".*The artifact xml-apis:xml-apis:jar:2.0.2 has been relocated to xml-apis:xml-apis:jar:1.0.b2.*");
+    private static final Pattern WARNING_SYS_MODULE_PATH = Pattern.compile(".*\\[WARNING\\] system modules path not set in conjunction with -source \\d+");
 
     public final Pattern[] errs;
 
@@ -147,6 +148,7 @@ public enum WhitelistLogLines {
                         WARNING_MISSING_OBJCOPY_RESULT_NATIVE,
                         // https://github.com/netty/netty/issues/11020
                         Pattern.compile(".*Can not find io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider in the classpath, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS.*"),
+                        WARNING_SYS_MODULE_PATH
                 };
             case WINDOWS:
                 return new Pattern[] {
@@ -161,6 +163,7 @@ public enum WhitelistLogLines {
                         Pattern.compile(".*Unknown module: org.graalvm.nativeimage.*"),
                         // TODO https://github.com/quarkusio/quarkus/issues/36813
                         Pattern.compile(".*Unrecognized configuration file .*application.yml found.*"),
+                        WARNING_SYS_MODULE_PATH
                 };
             case LINUX:
             	return new Pattern[] {
@@ -169,6 +172,7 @@ public enum WhitelistLogLines {
                         COMMON_SLF4J_JBOSS_LOGMANAGER_DEPENDENCY_TREE,
                         // TODO https://github.com/quarkusio/quarkus/issues/36053
                         Pattern.compile(".*Unknown module: org.graalvm.nativeimage.*"),
+                        WARNING_SYS_MODULE_PATH
                 };
         }
         return new Pattern[] {};


### PR DESCRIPTION
This is adding a simple https://github.com/async-profiler/async-profiler support (right now for version 3.0) just on the start-stop test.

I didn't tried to abstract nor optimize it, really, but in the config script, it enables attaching async-profiler's agent, while stopping right after the first request is completed.

If we would need to start/stop the profiler again in other stages of the test will need some refactoring/adding more methods.

By default it profile cpu events and it is enabled just for linux. 
We could decide to use https://github.com/jvm-profiling-tools/ap-loader and have mac support from day one, but given that is meant to run on the CI I see no reasons for that.