### PR TITLE
Rename webjars locator and bump Quarkus version

### DIFF
--- a/app-full-microprofile/pom.xml
+++ b/app-full-microprofile/pom.xml
@@ -83,7 +83,7 @@
                 </property>
             </activation>
             <properties>
-                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
             </properties>
         </profile>
     </profiles>

--- a/app-jakarta-rest-minimal/pom.xml
+++ b/app-jakarta-rest-minimal/pom.xml
@@ -51,7 +51,7 @@
                 </property>
             </activation>
             <properties>
-                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>3.9.4</quarkus.version>
+        <quarkus.version>3.11.0</quarkus.version>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus-ide-config.version>3.9.4</quarkus-ide-config.version>
+        <quarkus-ide-config.version>3.11.0</quarkus-ide-config.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.version>3.10.1</maven.compiler.version>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
@@ -50,7 +50,7 @@ public enum CodeQuarkusExtensions {
     QUARKUS_SMALLRYE_OPENAPI("quarkus-smallrye-openapi", "SmallRye OpenAPI", "ARC", true),
     QUARKUS_UNDERTOW("quarkus-undertow", "Undertow Servlet", "LMC", true),
     QUARKUS_SMALLRYE_STORK("quarkus-smallrye-stork", "SmallRye Stork", "ignored", false),
-    QUARKUS_WEBJARS_LOCATOR("quarkus-webjars-locator", "WebJar Locator", "XSP", false),
+    QUARKUS_WEBJARS_LOCATOR("quarkus-web-dependency-locator", "Web Dependency Locator", "ignored", false),
     QUARKUS_HAL("quarkus-hal", "Hypertext Application Language (HAL)", "ignored", false),
     QUARKUS_WEBSOCKETS("quarkus-websockets", "WebSockets", "JPE", true),
     QUARKUS_WEBSOCKETS_CLIENT("quarkus-websockets-client", "WebSockets Client", "YcS", true),

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -62,7 +62,7 @@ public enum WhitelistLogLines {
             Pattern.compile(".*maven-error-diagnostics.*"),
             Pattern.compile(".*errorprone.*"),
             Pattern.compile(".*error_prone_annotations.*"),
-            Pattern.compile(".*No WebJars were found in the project.*"),
+            Pattern.compile(".*No WebJars or mvnpm jars were found in the project.*"),
             // kubernetes-client tries to configure client from service account
             Pattern.compile(".*Error reading service account token from.*"),
             // We have disabled the Quarkus Registry Client (-DquarkusRegistryClient=false)


### PR DESCRIPTION
Quarkus rename webjars-locator to web-deoendency-locator. See [migration guide](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.11). This will fix daily CI

Also bumping Quarkus as we miss 3.10 release 

`quarkus.package.type` was changed in Quarkus 3.10 see [migration guide](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.10) 