### PR TITLE
Bump Quarkus to 3.12.1 and remove whitelisted log item fixed in 3.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>3.11.0</quarkus.version>
+        <quarkus.version>3.12.1</quarkus.version>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus-ide-config.version>3.11.0</quarkus-ide-config.version>
+        <quarkus-ide-config.version>3.12.1</quarkus-ide-config.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -39,9 +39,7 @@ public enum WhitelistLogLines {
             Pattern.compile("\\[Quarkus build analytics\\] Analytics remote config not received."),
             // netty 4 which doesn't have the relevant native config in the lib. See https://github.com/netty/netty/pull/13596
             Pattern.compile(".*Warning: Please re-evaluate whether any experimental option is required, and either remove or unlock it\\..*"),
-            Pattern.compile(".*Warning: The option '-H:ReflectionConfigurationResources=META-INF/native-image/io\\.netty/netty-transport/reflection-config\\.json' is experimental and must be enabled via.*"),
-            // TODO: remove next line when https://github.com/quarkusio/quarkus/issues/41351 gets fixed
-            Pattern.compile(".*Error Occurred After Shutdown.*java.lang.NullPointerException.*Cannot invoke.*io.smallrye.context.SmallRyeContextManager.defaultThreadContext.*"),
+            Pattern.compile(".*Warning: The option '-H:ReflectionConfigurationResources=META-INF/native-image/io\\.netty/netty-transport/reflection-config\\.json' is experimental and must be enabled via.*")
     }),
     GENERATED_SKELETON(new Pattern[]{
             // Harmless warning


### PR DESCRIPTION
- bumps Quarkus to 3.12.1
- removes https://github.com/quarkusio/quarkus/issues/41351 from whitelisted items as it's fixed in 3.12.1