### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,27 +7,27 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>3.11.0</quarkus.version>
+        <quarkus.version>3.13.0</quarkus.version>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus-ide-config.version>3.11.0</quarkus-ide-config.version>
+        <quarkus-ide-config.version>3.13.0</quarkus-ide-config.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.version>3.10.1</maven.compiler.version>
-        <maven.surefire.version>2.22.2</maven.surefire.version>
-        <maven.failsafe.version>2.22.2</maven.failsafe.version>
-        <maven.build.helper.version>3.3.0</maven.build.helper.version>
+        <maven.compiler.version>3.13.0</maven.compiler.version>
+        <maven.surefire.version>3.3.1</maven.surefire.version>
+        <maven.failsafe.version>3.3.1</maven.failsafe.version>
+        <maven.build.helper.version>3.6.0</maven.build.helper.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.jupiter.version>5.9.2</junit.jupiter.version>
-        <commons.io.version>2.11.0</commons.io.version>
-        <commons.lang.version>3.12.0</commons.lang.version>
-        <jboss-logging.version>3.5.0.Final</jboss-logging.version>
-        <log4j.version>2.19.0</log4j.version>
-        <playwright.version>1.30.0</playwright.version>
-        <vertx-grpc-server.version>4.5.7</vertx-grpc-server.version>
-        <formatter-maven-plugin.version>2.22.0</formatter-maven-plugin.version>
-        <impsort-maven-plugin.version>1.8.0</impsort-maven-plugin.version>
-        <xml-format-maven-plugin>3.2.2</xml-format-maven-plugin>
+        <junit.jupiter.version>5.10.3</junit.jupiter.version>
+        <commons.io.version>2.16.1</commons.io.version>
+        <commons.lang.version>3.15.0</commons.lang.version>
+        <jboss-logging.version>3.6.0.Final</jboss-logging.version>
+        <log4j.version>2.23.1</log4j.version>
+        <playwright.version>1.45.0</playwright.version>
+        <vertx-grpc-server.version>4.5.9</vertx-grpc-server.version>
+        <formatter-maven-plugin.version>2.24.1</formatter-maven-plugin.version>
+        <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>
+        <xml-format-maven-plugin>3.3.1</xml-format-maven-plugin>
         <opentelemetry-proto.version>1.3.2-alpha</opentelemetry-proto.version>
         <!-- Test to be executed by default (should be all of them) -->
         <includeTags>generator,startstop,bomtests,codequarkus,special-chars</includeTags>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <formatter-maven-plugin.version>2.22.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.8.0</impsort-maven-plugin.version>
         <xml-format-maven-plugin>3.2.2</xml-format-maven-plugin>
+        <opentelemetry-proto.version>1.3.2-alpha</opentelemetry-proto.version>
         <!-- Test to be executed by default (should be all of them) -->
         <includeTags>generator,startstop,bomtests,codequarkus,special-chars</includeTags>
         <!-- Default values for format -->
@@ -58,6 +59,12 @@
             <groupId>com.microsoft.playwright</groupId>
             <artifactId>playwright</artifactId>
             <version>${playwright.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.proto</groupId>
+            <artifactId>opentelemetry-proto</artifactId>
+            <version>${opentelemetry-proto.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
@@ -86,6 +86,7 @@ public class ArtifactGeneratorBOMTest {
             Files.createDirectories(Paths.get(repoDir));
 
             //Generator
+            LOGGER.info("Running inside " + appDir.getAbsolutePath());
             LOGGER.info(mn + ": Generator command " + String.join(" ", generatorCmd));
             generateLog = new File(logsDir + File.separator + "bom-artifact-generator.log");
             ExecutorService buildService = Executors.newFixedThreadPool(1);

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -268,7 +268,7 @@ public class ArtifactGeneratorTest {
         } else {
             LOGGER.info(mn + ": Testing setup: " + String.join(" ", generatorCmd));
         }
-
+        LOGGER.info("Running inside " + appDir.getAbsolutePath());
         try {
             // Cleanup
             cleanDirOrFile(appBaseDir.getAbsolutePath());

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/SpecialCharsTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/SpecialCharsTest.java
@@ -177,6 +177,7 @@ public class SpecialCharsTest {
     }
 
     @Test
+    @Disabled("TODO: https://github.com/quarkusio/quarkus/issues/42248")
     public void specialJVM(TestInfo testInfo) throws IOException, InterruptedException {
         testRuntime(testInfo, Apps.JAKARTA_REST_MINIMAL, MvnCmds.JVM, ",;~!@#$%^&()");
     }
@@ -190,6 +191,7 @@ public class SpecialCharsTest {
     @Test
     @Tag("native")
     @DisabledOnOs({OS.WINDOWS}) // https://github.com/quarkusio/quarkus/issues/9707
+    @Disabled("TODO: https://github.com/quarkusio/quarkus/issues/42248")
     public void specialNative(TestInfo testInfo) throws IOException, InterruptedException {
         testRuntime(testInfo, Apps.JAKARTA_REST_MINIMAL, MvnCmds.NATIVE, ",;~!@#$%^&()");
     }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/SpecialCharsTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/SpecialCharsTest.java
@@ -60,8 +60,8 @@ public class SpecialCharsTest {
         File appDir = new File(appDestDir, app.dir);
         File appPomXml = new File(appDir, "pom.xml");
         File logsDir = new File(appDir, "special-chars-logs");
-        String cn = testInfo.getTestClass().get().getCanonicalName();
-        String mn = testInfo.getTestMethod().get().getName();
+        String canonicalName = testInfo.getTestClass().get().getCanonicalName();
+        String methodName = testInfo.getTestMethod().get().getName();
         LOGGER.info("Testing app: " + app + ", mode: " + mvnCmds.toString() + ", on path " + appDestDir);
         try {
             // Clean target directory
@@ -75,6 +75,7 @@ public class SpecialCharsTest {
             }
 
             // Copy to path with special characters
+            LOGGER.info("Copying " + appBaseDir + "to" + appDestDir);
             FileUtils.copyDirectoryToDirectory(appBaseDir, appDestDir);
 
             // Replace relative path to parent project
@@ -99,7 +100,7 @@ public class SpecialCharsTest {
                 baseBuildCmd.add("-Dquarkus.platform.group-id=" + getQuarkusGroupId());
                 cmd = getBuildCommand(baseBuildCmd.toArray(new String[0]));
 
-                appendln(whatIDidReport, "# " + cn + ", " + mn);
+                appendln(whatIDidReport, "# " + canonicalName + ", " + methodName);
                 appendln(whatIDidReport, (new Date()).toString());
                 appendln(whatIDidReport, appDir.getAbsolutePath());
                 appendlnSection(whatIDidReport, String.join(" ", cmd));
@@ -111,11 +112,11 @@ public class SpecialCharsTest {
                 buildService.awaitTermination(30, TimeUnit.MINUTES);
 
                 assertTrue(buildLogA.exists());
-                checkLog(cn, mn, app, mvnCmds, buildLogA);
+                checkLog(canonicalName, methodName, app, mvnCmds, buildLogA);
             }
 
             // Run
-            runLogA = new File(logsDir + File.separator + subdir +  "-" + mvnCmds.name().toLowerCase() + "-run.log");
+            runLogA = new File(logsDir + File.separator + subdir + "-" + mvnCmds.name().toLowerCase() + "-run.log");
 
             if (mvnCmds == MvnCmds.DEV) {
                 List<String> baseBuildCmd = new ArrayList<>();
@@ -148,12 +149,12 @@ public class SpecialCharsTest {
 
             // Archive logs
             if (buildLogA != null) {
-                archiveLog(cn, mn, buildLogA);
+                archiveLog(canonicalName, methodName, buildLogA);
             }
             if (runLogA != null) {
-                archiveLog(cn, mn, runLogA);
+                archiveLog(canonicalName, methodName, runLogA);
             }
-            writeReport(cn, mn, whatIDidReport.toString());
+            writeReport(canonicalName, methodName, whatIDidReport.toString());
 
             removeDirWithSpecialCharacters(appDestDir);
         }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -418,7 +418,7 @@ public class Commands {
         return false;
     }
 
-    // TODO we should get rid of it once Quarkus progresses with walid config per extension in generated examples
+    // TODO we should get rid of it once Quarkus progresses with valid config per extension in generated examples
     public static void confAppPropsForSkeleton(String appDir) throws IOException {
         // Config, see app-generated-skeleton/README.md
         final String appRelativePath =

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Logs.java
@@ -213,12 +213,16 @@ public class Logs {
             if (files != null) {
                 for (File file : files) {
                     if (!file.isDirectory()) {
-                        Files.copy(file.toPath(), Paths.get(destDir.toString(), file.getName()), REPLACE_EXISTING);
+                        Path target = Paths.get(destDir.toString(), file.getName());
+                        LOGGER.info("Saving log to " + target);
+                        Files.copy(file.toPath(), target, REPLACE_EXISTING);
                     }
                 }
             }
         } else {
-            Files.copy(log.toPath(), Paths.get(destDir.toString(), filename), REPLACE_EXISTING);
+            Path target = Paths.get(destDir.toString(), filename);
+            LOGGER.info("Saving log to " + target);
+            Files.copy(log.toPath(), target, REPLACE_EXISTING);
         }
     }
 
@@ -228,6 +232,7 @@ public class Logs {
         Files.write(Paths.get(destDir.toString(), "report.md"), text.getBytes(UTF_8), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
         Path agregateReport = Paths.get(getLogsDir().toString(), "aggregated-report.md");
         if (Files.notExists(agregateReport)) {
+            LOGGER.info("Saving report to " + agregateReport);
             Files.write(agregateReport, ("# Aggregated Report\n\n").getBytes(UTF_8), StandardOpenOption.CREATE);
         }
         Files.write(agregateReport, text.getBytes(UTF_8), StandardOpenOption.APPEND);

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/OpenTelemetryCollector.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/OpenTelemetryCollector.java
@@ -1,80 +1,77 @@
 package io.quarkus.ts.startstop.utils;
 
+import io.opentelemetry.proto.collector.trace.v1.ExportTracePartialSuccess;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
+import io.opentelemetry.proto.trace.v1.Span;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
-import io.vertx.grpc.common.GrpcMessage;
+import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.server.GrpcServer;
+import org.jboss.logging.Logger;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This simplistic collector allows us to test Vert.x-based traces exporter in Quarkus without starting a container.
  */
 public class OpenTelemetryCollector implements UnitTestResource {
-
+    private static final Logger LOGGER = Logger.getLogger(OpenTelemetryCollector.class.getName());
     private static final String HELLO_ENDPOINT_OPERATION_NAME = "GET /hello";
     private static final String GET_HELLO_INVOCATION_NOT_TRACED = HELLO_ENDPOINT_OPERATION_NAME + " invocation not traced";
     /**
      * If you change this port, you must also change respective 'quarkus.otel.exporter.otlp.traces.endpoint' value.
      */
     private static final int OTEL_COLLECTOR_PORT = 4317;
+    private static final int WEB_ENDPOINT = 16686; // Can be changed to anything, currently is the same as Jaeger.
     private static final String GET_HELLO_TRACES_PATH = "/recorded-traces/get-hello";
-    static final String GET_HELLO_TRACES_URL = "http://localhost:" + OTEL_COLLECTOR_PORT + GET_HELLO_TRACES_PATH;
     static final String GET_HELLO_INVOCATION_TRACED = HELLO_ENDPOINT_OPERATION_NAME + " invocation traced";
+    static final String GET_HELLO_TRACES_URL = "http://localhost:" + WEB_ENDPOINT + GET_HELLO_TRACES_PATH;
 
-    private final Closeable closeable;
-    private final RequestHandler requestHandler;
+    private final Vertx vertx;
+    private final Closeable backEnd;
+    private final Closeable frontEnd;
+    private final AtomicBoolean helloEndpointCallTraced = new AtomicBoolean(false);
 
 
     public OpenTelemetryCollector() {
-        this.closeable = createGrpcServer();
-        this.requestHandler = new RequestHandler();
-    }
-
-    private Closeable createGrpcServer() {
-        Vertx vertx = Vertx.vertx();
-        GrpcServer grpcProxy = GrpcServer.server(vertx);
-
-        // record incoming traces
-        grpcProxy.callHandler(reqFromQuarkus -> reqFromQuarkus.messageHandler(requestHandler::onReceivedTraces));
-
-        HttpServer httpServer = vertx.createHttpServer(new HttpServerOptions().setPort(OTEL_COLLECTOR_PORT));
-        httpServer.requestHandler(httpServerRequest -> {
-            if (httpServerRequest.path().contains(GET_HELLO_TRACES_PATH)) {
-                requestHandler.handleTracesRequest(httpServerRequest);
-            } else {
-                grpcProxy.handle(httpServerRequest);
-            }
-        }).listen();
-
-        // close resources
-        return () -> {
-            httpServer.close().toCompletionStage().toCompletableFuture().join();
-            vertx.close().toCompletionStage().toCompletableFuture().join();
-        };
+        vertx = Vertx.vertx();
+        this.backEnd = new GRPCTraceHandler(vertx);
+        this.frontEnd = new FrontEnd(vertx);
     }
 
     @Override
     public void close() throws IOException {
-        closeable.close();
+        frontEnd.close();
+        backEnd.close();
+        vertx.close().toCompletionStage().toCompletableFuture().join();
     }
 
     @Override
     public void reset() {
-        requestHandler.resetTraces();
+        helloEndpointCallTraced.set(false);
     }
 
-    private static class RequestHandler {
+    private class FrontEnd implements Closeable {
+        private final HttpServer httpServer;
 
-        private final AtomicBoolean helloEndpointCallTraced = new AtomicBoolean(false);
+        public FrontEnd(Vertx vertx) {
+            httpServer = vertx
+                    .createHttpServer()
+                    .requestHandler(this::handleTracesRequest);
+            httpServer.listen(WEB_ENDPOINT);
+        }
 
         private void handleTracesRequest(HttpServerRequest request) {
             final String response;
-            if (helloEndpointCallTraced.get()) {
+            boolean isTraced = helloEndpointCallTraced.get();
+            if (isTraced) {
                 response = GET_HELLO_INVOCATION_TRACED;
             } else {
                 response = GET_HELLO_INVOCATION_NOT_TRACED;
@@ -82,18 +79,58 @@ public class OpenTelemetryCollector implements UnitTestResource {
             request.response().end(response);
         }
 
-        private void onReceivedTraces(GrpcMessage exportedTraces) {
-            if (!helloEndpointCallTraced.get() && helloEndpointCallTraced(exportedTraces)) {
-                helloEndpointCallTraced.set(true);
-            }
+        @Override
+        public void close() {
+            LOGGER.info("Closing the server");
+            httpServer.close().toCompletionStage().toCompletableFuture().join();
+            LOGGER.info("The server was closed");
+        }
+    }
+
+    class GRPCTraceHandler implements Closeable {
+        private final HttpServer httpServer;
+
+        public GRPCTraceHandler(Vertx vertx) {
+            GrpcServer grpcHandler = GrpcServer.server(vertx);
+
+            // record incoming traces
+            grpcHandler.callHandler(TraceServiceGrpc.getExportMethod(), request -> {
+                // https://vertx.io/docs/vertx-grpc/java/#_streaming_request, because Quarkus uses streaming since 3.13
+                request.handler((ExportTraceServiceRequest tracesRequest) -> {
+                    LOGGER.info("Processing traces");
+                    List<String> traces = tracesRequest.getResourceSpansList().stream()
+                            .flatMap(resourceSpans -> resourceSpans.getScopeSpansList().stream())
+                            .flatMap(scopeSpans -> scopeSpans.getSpansList().stream())
+                            .map(Span::getName)
+                            .toList();
+
+                    for (String trace : traces) {
+                        if (trace.contains(HELLO_ENDPOINT_OPERATION_NAME)) {
+                            LOGGER.info("Received trace for " + HELLO_ENDPOINT_OPERATION_NAME);
+                            helloEndpointCallTraced.compareAndSet(false, true);
+                        }
+                    }
+                });
+                request.endHandler(v -> {
+                    // https://opentelemetry.io/docs/specs/otlp/#full-success
+                    request.response().end(ExportTraceServiceResponse.newBuilder().build());
+                });
+                request.exceptionHandler(err -> { // https://opentelemetry.io/docs/specs/otlp/#failures
+                    request.response().status(GrpcStatus.INVALID_ARGUMENT).end();
+                });
+            });
+            httpServer = vertx
+                    .createHttpServer()
+                    .requestHandler(grpcHandler);
+            httpServer.listen(OTEL_COLLECTOR_PORT);
+            LOGGER.info("The listener started!");
         }
 
-        private void resetTraces() {
-            helloEndpointCallTraced.set(false);
-        }
-
-        private static boolean helloEndpointCallTraced(GrpcMessage msgFromQuarkus) {
-            return msgFromQuarkus.payload().toString().contains(HELLO_ENDPOINT_OPERATION_NAME);
+        @Override
+        public void close() {
+            LOGGER.info("Closing the listener");
+            httpServer.close().toCompletionStage().toCompletableFuture().join();
+            LOGGER.info("The listener was closed");
         }
     }
 }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -40,9 +40,6 @@ public enum WhitelistLogLines {
             // netty 4 which doesn't have the relevant native config in the lib. See https://github.com/netty/netty/pull/13596
             Pattern.compile(".*Warning: Please re-evaluate whether any experimental option is required, and either remove or unlock it\\..*"),
             Pattern.compile(".*Warning: The option '-H:ReflectionConfigurationResources=META-INF/native-image/io\\.netty/netty-transport/reflection-config\\.json' is experimental and must be enabled via.*"),
-            // TODO: remove next two lines when update to quarkus 3.13 or newer and fix from https://github.com/quarkusio/quarkus/issues/41351 is applied
-            Pattern.compile(".*Error Occurred After Shutdown.*java.lang.NullPointerException.*Cannot invoke.*io.smallrye.context.SmallRyeContextManager.defaultThreadContext.*"),
-            Pattern.compile(".*vert.x-eventloop-thread-2.*Error Occurred After Shutdown.*java.lang.NullPointerException"),
     }),
     GENERATED_SKELETON(new Pattern[]{
             // Harmless warning
@@ -105,8 +102,8 @@ public enum WhitelistLogLines {
             Pattern.compile(".*Annotation processing is enabled because one or more processors were found.*"),
             // https://github.com/quarkusio/quarkus/issues/38711
             Pattern.compile(".*SplitPackageProcessor.*Following packages were detected in multiple archives.*"),
-            // TODO: remove next line when 3.7.3 is released, see https://github.com/quarkusio/quarkus/pull/38710
-            Pattern.compile(".*This instance of GraphiQLHandler has been created with a deprecated method.*")
+            // TODO: https://github.com/quarkusio/quarkus/issues/42237
+            Pattern.compile(".*Failed to index org.springframework.aot.hint.annotation.Reflective.*")
     }),
     // Quarkus is not being gratefully shutdown in Windows when running in Dev mode.
     // Reported by https://github.com/quarkusio/quarkus/issues/14647.
@@ -159,10 +156,6 @@ public enum WhitelistLogLines {
                         WARNING_MISSING_OBJCOPY_RESULT_NATIVE,
                         // Randomly prints some SLF4J traces. Reported by https://github.com/quarkusio/quarkus/issues/16896
                         Pattern.compile(".*SLF4J:.*"),
-                        // TODO https://github.com/quarkusio/quarkus/issues/36053
-                        Pattern.compile(".*Unknown module: org.graalvm.nativeimage.*"),
-                        // TODO https://github.com/quarkusio/quarkus/issues/36813
-                        Pattern.compile(".*Unrecognized configuration file .*application.yml found.*"),
                         WARNING_SYS_MODULE_PATH
                 };
             case LINUX:
@@ -170,8 +163,6 @@ public enum WhitelistLogLines {
                         XML_APIS_RELOCATED,
                         COMMON_SLF4J_API_DEPENDENCY_TREE,
                         COMMON_SLF4J_JBOSS_LOGMANAGER_DEPENDENCY_TREE,
-                        // TODO https://github.com/quarkusio/quarkus/issues/36053
-                        Pattern.compile(".*Unknown module: org.graalvm.nativeimage.*"),
                         WARNING_SYS_MODULE_PATH
                 };
         }


### PR DESCRIPTION
- Change all dependencies to the latest versions
- Add a bit of debugging related to https://github.com/quarkusio/quarkus/issues/42237 and https://github.com/quarkusio/quarkus/issues/42248
- After 3.13.0 quarkus OTEL exporter uses GRPC streams to export traces.
  Our hacked together OTEL server(added in https://github.com/quarkus-qe/quarkus-startstop/pull/378) could not handle that and was rewritten to conform to OTEL specifications more.
  
Related issue: QQE-844