### PR TITLE
Fix whitelist regex for 41351 issue

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -40,8 +40,9 @@ public enum WhitelistLogLines {
             // netty 4 which doesn't have the relevant native config in the lib. See https://github.com/netty/netty/pull/13596
             Pattern.compile(".*Warning: Please re-evaluate whether any experimental option is required, and either remove or unlock it\\..*"),
             Pattern.compile(".*Warning: The option '-H:ReflectionConfigurationResources=META-INF/native-image/io\\.netty/netty-transport/reflection-config\\.json' is experimental and must be enabled via.*"),
-            // TODO: remove next line when https://github.com/quarkusio/quarkus/issues/41351 gets fixed
+            // TODO: remove next two lines when update to quarkus 3.13 or newer and fix from https://github.com/quarkusio/quarkus/issues/41351 is applied
             Pattern.compile(".*Error Occurred After Shutdown.*java.lang.NullPointerException.*Cannot invoke.*io.smallrye.context.SmallRyeContextManager.defaultThreadContext.*"),
+            Pattern.compile(".*vert.x-eventloop-thread-2.*Error Occurred After Shutdown.*java.lang.NullPointerException"),
     }),
     GENERATED_SKELETON(new Pattern[]{
             // Harmless warning


### PR DESCRIPTION
Fix whitelist regex for issue causing our daily tests to fail. Failure is related to https://github.com/quarkusio/quarkus/issues/41351.

It seems to still be the same/similar issue, but original regex didn't work with line separator "\n" as regex charater "." (any character) does not match newline.