### PR TITLE
Increase RSS memory limit for MP native binary

### DIFF
--- a/app-full-microprofile/threshold.properties
+++ b/app-full-microprofile/threshold.properties
@@ -1,7 +1,7 @@
 linux.jvm.time.to.first.ok.request.threshold.ms=2500
 linux.jvm.RSS.threshold.kB=220000
 linux.native.time.to.first.ok.request.threshold.ms=70
-linux.native.RSS.threshold.kB=83000
+linux.native.RSS.threshold.kB=90000
 windows.jvm.time.to.first.ok.request.threshold.ms=3500
 windows.jvm.RSS.threshold.kB=5000
 windows.native.time.to.first.ok.request.threshold.ms=500


### PR DESCRIPTION
Increase RSS memory limit for MP native binary (used in GH Actions runs)

Details about increased memory usage in https://github.com/quarkusio/quarkus/issues/42506