### PR TITLE
Switch back to reactive artifacts for easier 3.8 and 3.15 comparison

### DIFF
--- a/app-full-microprofile/pom.xml
+++ b/app-full-microprofile/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-jackson</artifactId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client</artifactId>
+            <artifactId>quarkus-rest-client-reactive</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/app-jakarta-rest-minimal/pom.xml
+++ b/app-jakarta-rest-minimal/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest</artifactId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -23,6 +23,7 @@ public enum WhitelistLogLines {
             // netty 4 which doesn't have the relevant native config in the lib. See https://github.com/netty/netty/pull/13596
             Pattern.compile(".*Warning: Please re-evaluate whether any experimental option is required, and either remove or unlock it\\..*"),
             Pattern.compile(".*Warning: The option '-H:ReflectionConfigurationResources=META-INF/native-image/io\\.netty/netty-transport/reflection-config\\.json' is experimental and must be enabled via.*"),
+            Pattern.compile(".*has been relocated.*"),
     }),
     FULL_MICROPROFILE(new Pattern[]{
             // Some artifacts names...
@@ -40,6 +41,7 @@ public enum WhitelistLogLines {
             // netty 4 which doesn't have the relevant native config in the lib. See https://github.com/netty/netty/pull/13596
             Pattern.compile(".*Warning: Please re-evaluate whether any experimental option is required, and either remove or unlock it\\..*"),
             Pattern.compile(".*Warning: The option '-H:ReflectionConfigurationResources=META-INF/native-image/io\\.netty/netty-transport/reflection-config\\.json' is experimental and must be enabled via.*"),
+            Pattern.compile(".*has been relocated.*"),
     }),
     GENERATED_SKELETON(new Pattern[]{
             // Harmless warning


### PR DESCRIPTION
Switch back to reactive artifacts for easier 3.8 and 3.15 comparison

One can do things like this without the need to change branches:
```
mvn clean package -f app-full-microprofile -Dnative -Dquarkus.native.monitoring=jfr -Dquarkus.version=3.13.2
mvn clean package -f app-full-microprofile -Dnative -Dquarkus.native.monitoring=jfr -Dquarkus.version=3.8.5
```

Artifacts like `quarkus-rest-jackson` were introduced in 3.9, there are relocations available for older artifacts names and thus the testing apps can be simply compiled with 3.8 and 3.latest