### PR TITLE
[3.2] Run Java versions validation against 3.2 stream

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -96,7 +96,7 @@ public class CodeQuarkusSiteTest {
 
     @Test
     public void validatePresenceOfJavaVersionSelect(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl + "?S=com.redhat.quarkus.platform%3A3.2", 60);
         LOGGER.info("Trying to find element: " + elementJavaVersionSelectByXpath);
         Locator javaVersionSelect = page.locator(elementJavaVersionSelectByXpath);
         assertTrue(javaVersionSelect.count() == 1, "Element: " + elementJavaVersionSelectByXpath + " is missing!");


### PR DESCRIPTION
Fix failures detected in https://github.com/quarkus-qe/quarkus-startstop/pull/393

https://code.quarkus.redhat.com/?S=com.redhat.quarkus.platform%3A3.2 page should be used in `validatePresenceOfJavaVersionSelect`  test to retrieve correct information about current supported Java versions