### PR TITLE
Rename quarkus-rest(easy) dependencies

### DIFF
--- a/app-full-microprofile/pom.xml
+++ b/app-full-microprofile/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-reactive</artifactId>
+            <artifactId>quarkus-rest-client</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/app-jakarta-rest-minimal/pom.xml
+++ b/app-jakarta-rest-minimal/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive</artifactId>
+            <artifactId>quarkus-rest</artifactId>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Rename dependencies as was done in https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.9