### PR TITLE
Rename quarkus-rest(easy) dependencies

### DIFF
--- a/app-full-microprofile/pom.xml
+++ b/app-full-microprofile/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-reactive</artifactId>
+            <artifactId>quarkus-rest-client</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/app-jakarta-rest-minimal/pom.xml
+++ b/app-jakarta-rest-minimal/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive</artifactId>
+            <artifactId>quarkus-rest</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -23,7 +23,6 @@ public enum WhitelistLogLines {
             // netty 4 which doesn't have the relevant native config in the lib. See https://github.com/netty/netty/pull/13596
             Pattern.compile(".*Warning: Please re-evaluate whether any experimental option is required, and either remove or unlock it\\..*"),
             Pattern.compile(".*Warning: The option '-H:ReflectionConfigurationResources=META-INF/native-image/io\\.netty/netty-transport/reflection-config\\.json' is experimental and must be enabled via.*"),
-            Pattern.compile(".*has been relocated.*"),
     }),
     FULL_MICROPROFILE(new Pattern[]{
             // Some artifacts names...
@@ -41,7 +40,6 @@ public enum WhitelistLogLines {
             // netty 4 which doesn't have the relevant native config in the lib. See https://github.com/netty/netty/pull/13596
             Pattern.compile(".*Warning: Please re-evaluate whether any experimental option is required, and either remove or unlock it\\..*"),
             Pattern.compile(".*Warning: The option '-H:ReflectionConfigurationResources=META-INF/native-image/io\\.netty/netty-transport/reflection-config\\.json' is experimental and must be enabled via.*"),
-            Pattern.compile(".*has been relocated.*"),
     }),
     GENERATED_SKELETON(new Pattern[]{
             // Harmless warning


### PR DESCRIPTION
Rename dependencies as was done in https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.9