### PR TITLE
[3.15] Use Quarkus 3.15.0.CR1, code.quarkus tests against 3.15 stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <quarkus.version>3.14.1</quarkus.version>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus-ide-config.version>3.14.1</quarkus-ide-config.version>
+        <quarkus-ide-config.version>3.15.0.CR1</quarkus-ide-config.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -41,7 +41,7 @@ public class CodeQuarkusSiteTest {
     private static final Logger LOGGER = Logger.getLogger(CodeQuarkusSiteTest.class.getName());
 
     public static final String pageLoadedSelector = ".extension-category";
-    public static final String webPageUrl = Commands.getCodeQuarkusURL("https://code.quarkus.redhat.com/");
+    public static final String webPageUrl = Commands.getCodeQuarkusURL("https://code.quarkus.redhat.com/?S=com.redhat.quarkus.platform%3A3.15");
     public static final String elementTitleByText = "Quarkus - Start coding with code.quarkus.redhat.com";
     public static final String elementIconByXpath = "//link[@rel=\"shortcut icon\"][@href=\"https://www.redhat.com/favicon.ico\"]";
     public static final String elementJavaVersionSelectByXpath = "//select[@id=\"javaversion\"]";

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -322,7 +322,7 @@ public class Commands {
      */
     public static String download(Collection<CodeQuarkusExtensions> extensions, String destinationZipFile) throws IOException {
         String downloadURL = getCodeQuarkusURL() + "/api/download?" +
-                extensions.stream().map(x -> "e=" + x.id).collect(Collectors.joining("&"));
+                extensions.stream().map(x -> "e=" + x.id).collect(Collectors.joining("&")) + "&S=3.15";
         return download(downloadURL, destinationZipFile);
     }
 
@@ -344,7 +344,7 @@ public class Commands {
     public static String download(Collection<CodeQuarkusExtensions> extensions, String destinationZipFile, int javaVersion) throws IOException {
         String downloadURL = getCodeQuarkusURL() + "/api/download?" +
                 extensions.stream().map(x -> "e=" + x.id).collect(Collectors.joining("&")) +
-                "&j=" + javaVersion;
+                "&j=" + javaVersion + "&S=3.15";
         return download(downloadURL, destinationZipFile);
     }
 


### PR DESCRIPTION

 * Run relevant code.quarkus tests against 3.15 stream
 * Move to Quarkus 3.15.0.CR1