### PR TITLE
[3.15] Fix CodeQuarkusSiteTest, do not modify fallback webPageUrl

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -41,7 +41,7 @@ public class CodeQuarkusSiteTest {
     private static final Logger LOGGER = Logger.getLogger(CodeQuarkusSiteTest.class.getName());
 
     public static final String pageLoadedSelector = ".extension-category";
-    public static final String webPageUrl = Commands.getCodeQuarkusURL("https://code.quarkus.redhat.com/?S=com.redhat.quarkus.platform%3A3.15");
+    public static final String webPageUrl = Commands.getCodeQuarkusURL("https://code.quarkus.redhat.com/");
     public static final String elementTitleByText = "Quarkus - Start coding with code.quarkus.redhat.com";
     public static final String elementIconByXpath = "//link[@rel=\"shortcut icon\"][@href=\"https://www.redhat.com/favicon.ico\"]";
     public static final String elementJavaVersionSelectByXpath = "//select[@id=\"javaversion\"]";
@@ -136,7 +136,7 @@ public class CodeQuarkusSiteTest {
         String quarkusPlatformVersion = getQuarkusVersion();
         Assumptions.assumeTrue(quarkusPlatformVersion.contains("redhat"));
 
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl + "?S=com.redhat.quarkus.platform%3A3.15", 60);
         LOGGER.info("Trying to find element: " + elementQuarkusPlatformVersionByXpath);
         String quarkusPlatformVersionFromWeb = page.locator(elementQuarkusPlatformVersionByXpath).elementHandle().getAttribute("title");
 


### PR DESCRIPTION
Fix CodeQuarkusSiteTest, do not modify fallback webPageUrl

Fixes failure from https://github.com/quarkus-qe/quarkus-startstop/pull/399 which was merged before I could get to it.