### PR TITLE
[3.8] Whitelist for failed exports of spans after shutdown initiation

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -40,8 +40,8 @@ public enum WhitelistLogLines {
             // netty 4 which doesn't have the relevant native config in the lib. See https://github.com/netty/netty/pull/13596
             Pattern.compile(".*Warning: Please re-evaluate whether any experimental option is required, and either remove or unlock it\\..*"),
             Pattern.compile(".*Warning: The option '-H:ReflectionConfigurationResources=META-INF/native-image/io\\.netty/netty-transport/reflection-config\\.json' is experimental and must be enabled via.*"),
-            // TODO: remove next line when https://github.com/quarkusio/quarkus/issues/41351 gets fixed
-            Pattern.compile(".*Error Occurred After Shutdown.*java.lang.NullPointerException.*Cannot invoke.*io.smallrye.context.SmallRyeContextManager.defaultThreadContext.*"),
+            // https://github.com/quarkusio/quarkus/issues/41351#issuecomment-2352357830
+            Pattern.compile(".*Failed to export spans.*Error Occurred After Shutdown.*"),
     }),
     GENERATED_SKELETON(new Pattern[]{
             // Harmless warning


### PR DESCRIPTION
Whitelist for failed exports of spans after shutdown initiation

Targeting just 3.8 as 3.15 and main have slightly reworked some parts around shutdown. The "Failed to export spans. The request could not be executed. Full error message: null [Error Occurred After Shutdown]" message may or may not occur there.