### PR TITLE
Refactor CodeQuarkusExtensions enum by adding REST CSFR extension, RESTEasy Classic bucket and drop commented out code that is no longer relevant

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -202,6 +202,11 @@ public class CodeQuarkusTest {
     }
 
     @Test
+    public void supportedRestEasyClassicExtensions(TestInfo testInfo) throws Exception {
+        testRuntime(testInfo, CodeQuarkusExtensions.getRestEasyClassicExtensions(), MvnCmds.MVNW_DEV);
+    }
+    
+    @Test
     public void notSupportedExtensionsSubsetA(TestInfo testInfo) throws Exception {
         testRuntime(testInfo, notSupportedEx.get(0).subList(0, Math.min(10, notSupportedEx.get(0).size())), MvnCmds.MVNW_DEV);
     }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
@@ -74,8 +74,6 @@ public enum CodeQuarkusExtensions {
     // The Blaze-Persistence dependency is present but no persistence units have been defined.
     // BLAZE_PERSISTENCE_INTEGRATION_QUARKUS("blaze-persistence-integration-quarkus", "Blaze-Persistence", "weW", false),
     QUARKUS_CACHE("quarkus-cache", "Cache", "W1i", true),
-    // https://issues.redhat.com/browse/QUARKUS-1295
-//    QUARKUS_ELASTICSEARCH_REST_HIGH_LEVEL_CLIENT("quarkus-elasticsearch-rest-high-level-client", "Elasticsearch REST High Level Client", "OJe", false),
     QUARKUS_ELASTICSEARCH_REST_CLIENT("quarkus-elasticsearch-rest-client", "Elasticsearch REST client", "NhW", false),
     QUARKUS_FLYWAY("quarkus-flyway", "Flyway", "wTM", false),
     QUARKUS_HIBERNATE_ENVERS("quarkus-hibernate-envers", "Hibernate Envers", "8j9", false),

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
@@ -93,8 +93,6 @@ public enum CodeQuarkusExtensions {
     // Caused by: java.lang.IllegalStateException: 'quarkus-narayana-lra' can only work if 'quarkus-resteasy-jackson' or 'quarkus-resteasy-reactive-jackson' is present
     // QUARKUS_NARAYANA_LRA("quarkus-narayana-lra", "Narayana LRA - LRA Participant Support", "O8P", false),
     QUARKUS_NARAYANA_STM("quarkus-narayana-stm", "Narayana STM - Software Transactional Memory", "Nl9", false),
-    // https://issues.redhat.com/browse/QUARKUS-1294
-//    QUARKUS_REDIS_CLIENT("quarkus-redis-client", "Redis Client", "jlX", false),
     QUARKUS_MESSAGING("quarkus-messaging", "Messaging", "ignored", true),
     // https://github.com/quarkusio/quarkus/issues/23383
 //    QUARKUS_SMALLRYE_REACTIVE_MESSAGING_AMQP("quarkus-smallrye-reactive-messaging-amqp", "SmallRye Reactive Messaging - AMQP Connector", "ur3", true),

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
@@ -18,8 +18,7 @@ public enum CodeQuarkusExtensions {
     QUARKUS_REST_CLIENT_REACTIVE_JAXB("quarkus-rest-client-jaxb", "REST Client JAXB", "ignored", true),
     QUARKUS_REST_CLIENT_REACTIVE_JSONB("quarkus-rest-client-jsonb", "REST Client JSON-B", "ignored", true),
     QUARKUS_REST_CLIENT_REACTIVE_KOTLIN_SERIALIZATION("quarkus-rest-client-kotlin-serialization", "REST Client Kotlin Serialization", "ignored", false),
-    // Should be directly in RESTEasy Reactive
-    // QUARKUS_CSRF_REACTIVE("quarkus-csrf-reactive", "Cross-Site Request Forgery Prevention Filter Reactive", "ignored", false),
+    QUARKUS_REST_CSRF("quarkus-rest-csrf", "Quarkus REST Cross-Site Request Forgery Prevention Filter", "ignored", false),
     QUARKUS_OIDC_CLIENT_REACTIVE_FILTER("quarkus-rest-client-oidc-filter", "REST Client - OpenID Connect Filter", "ignored", true),
     QUARKUS_OIDC_TOKEN_PROPAGATION_REACTIVE("quarkus-rest-client-oidc-token-propagation", "REST Client - OpenID Connect Token Propagation", "ignored", false),
 

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/CodeQuarkusExtensions.java
@@ -78,8 +78,6 @@ public enum CodeQuarkusExtensions {
 //    QUARKUS_ELASTICSEARCH_REST_HIGH_LEVEL_CLIENT("quarkus-elasticsearch-rest-high-level-client", "Elasticsearch REST High Level Client", "OJe", false),
     QUARKUS_ELASTICSEARCH_REST_CLIENT("quarkus-elasticsearch-rest-client", "Elasticsearch REST client", "NhW", false),
     QUARKUS_FLYWAY("quarkus-flyway", "Flyway", "wTM", false),
-    // TODO Not present in the 3.0 platform
-//    QUARKUS_HAZELCAST_CLIENT("quarkus-hazelcast-client", "Hazelcast Client", "yii", false),
     QUARKUS_HIBERNATE_ENVERS("quarkus-hibernate-envers", "Hibernate Envers", "8j9", false),
     QUARKUS_HIBERNATE_ORM_PANACHE_KOTLIN("quarkus-hibernate-orm-panache-kotlin", "Hibernate ORM with Panache and Kotlin", "O3q", false),
     QUARKUS_HIBERNATE_REACTIVE("quarkus-hibernate-reactive", "Hibernate Reactive", "r1s", false),


### PR DESCRIPTION
- Quarkus Hazelcast extension cannot be found in RHBQ/Community platform, looks dead
- https://issues.redhat.com/browse/QUARKUS-1294 is fixed, but Quarkus REDIS client is already among extensions, so dropping duplicate record
- dropping `quarkus-elasticsearch-rest-high-level-client` as it doesn't exist anymore https://github.com/quarkusio/quarkus/pull/31997
- adding back Quarkus CSFR as this PR https://github.com/quarkus-qe/quarkus-startstop/commit/25587f2cf474320be36b4a25faa80b5f626b3608 said it should be in RESTEasy Reactive. No idea what it means, but I checked and the CSRF is not included in Quarkus REST
- adding a bucket for RESTEasy Classic extensions as they cannot be mixed with Quarkus REST extensions, it's but a smoke check