### PR TITLE
Adjust code.quarkus site tests to the new layout with presets

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -40,7 +40,7 @@ public class CodeQuarkusSiteTest {
 
     private static final Logger LOGGER = Logger.getLogger(CodeQuarkusSiteTest.class.getName());
 
-    public static final String pageLoadedSelector = ".extension-category";
+    public static final String pageLoadedSelector = ".project-extensions";
     public static final String webPageUrl = Commands.getCodeQuarkusURL("https://code.quarkus.redhat.com/");
     public static final String elementTitleByText = "Quarkus - Start coding with code.quarkus.redhat.com";
     public static final String elementIconByXpath = "//link[@rel=\"shortcut icon\"][@href=\"https://www.redhat.com/favicon.ico\"]";
@@ -95,10 +95,10 @@ public class CodeQuarkusSiteTest {
 
     @Test
     public void validatePresenceOfSupportedFlags(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl + "/?e=grpc", 60);
         LOGGER.info("Trying to find element: " + elementSupportedFlagByXpath);
         Locator supportedExtensions = page.locator(elementSupportedFlagByXpath);
-        assertTrue(supportedExtensions.count() > 1, "Element: " + elementSupportedFlagByXpath + " is missing!");
+        assertTrue(supportedExtensions.count() >= 1, "Element: " + elementSupportedFlagByXpath + " is missing!");
     }
 
     @Test


### PR DESCRIPTION
Adjust code.quarkus site tests to the new layout with presets, this fixes failures we have in daily CI - https://github.com/quarkus-qe/quarkus-startstop/actions/workflows/ci.yaml

 * https://code.quarkus.redhat.com was updated to have presets 
 * new pageLoadedSelector was identified to work with old and new version
 * `validatePresenceOfSupportedFlags` now checks grpc extension URL because the default page has presets without a visible list of extensions

Example commands for execution (code-3-15-1 has old version deployed):
```
mvn clean verify -Ptestsuite-community-no-native -Dtest=CodeQuarkusSiteTest
mvn clean verify -Ptestsuite-community-no-native -Dtest=CodeQuarkusSiteTest -Dcode.quarkus.url=https://code-3-15-1-redhat-00003.apps.ocp-c1.prod.psi.redhat.com/
```

I will create backports for 3.8 and 3.15 once this gets merged, I spoke with @ia3andy and he confirmed that the latest version will be also used in temporary instances. 