### PR TITLE
[3.8] Adjust code.quarkus site tests to the new layout with presets

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -40,7 +40,7 @@ public class CodeQuarkusSiteTest {
 
     private static final Logger LOGGER = Logger.getLogger(CodeQuarkusSiteTest.class.getName());
 
-    public static final String pageLoadedSelector = ".extension-category";
+    public static final String pageLoadedSelector = ".project-extensions";
     public static final String webPageUrl = Commands.getCodeQuarkusURL("https://code.quarkus.redhat.com/");
     public static final String elementTitleByText = "Quarkus - Start coding with code.quarkus.redhat.com";
     public static final String elementIconByXpath = "//link[@rel=\"shortcut icon\"][@href=\"https://www.redhat.com/favicon.ico\"]";
@@ -95,10 +95,10 @@ public class CodeQuarkusSiteTest {
 
     @Test
     public void validatePresenceOfSupportedFlags(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl + "/?e=grpc", 60);
         LOGGER.info("Trying to find element: " + elementSupportedFlagByXpath);
         Locator supportedExtensions = page.locator(elementSupportedFlagByXpath);
-        assertTrue(supportedExtensions.count() > 1, "Element: " + elementSupportedFlagByXpath + " is missing!");
+        assertTrue(supportedExtensions.count() >= 1, "Element: " + elementSupportedFlagByXpath + " is missing!");
     }
 
     @Test


### PR DESCRIPTION
Backport of https://github.com/quarkus-qe/quarkus-startstop/pull/409

* new pageLoadedSelector was identified to work with old and new version
* validatePresenceOfSupportedFlags now checks grpc extension URL because the default page has presets without a visible list of extensions