### PR TITLE
[3.15] Switch site test to use Firefox

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -56,9 +56,10 @@ public class CodeQuarkusSiteTest {
     @BeforeAll
     public void init(){
         Playwright playwright = Playwright.create();
-        Browser browser = playwright.chromium().launch(new BrowserType.LaunchOptions()
-                .setArgs(List.of("--headless", "--disable-gpu", "--no-sandbox")));
-        browserContext = browser.newContext();
+        Browser browser = playwright.firefox().launch(new BrowserType.LaunchOptions().setHeadless(true));
+        Browser.NewContextOptions options = new Browser.NewContextOptions();
+        options.ignoreHTTPSErrors = true;
+        browserContext = browser.newContext(options);
         LOGGER.info("Incognito browser session has been created");
     }
 


### PR DESCRIPTION
* Chromium managed by Playwright doesn't properly work on aarch64 right now, so let's use Firefox in CodeQuarkusSiteTest.

(cherry picked from commit 1e2fab86c71a10d009b62b33c2045bb6c962f850)

Backport of https://github.com/quarkus-qe/quarkus-startstop/pull/412