### PR TITLE
Bump Quarkus to 3.16.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>3.14.4</quarkus.version>
+        <quarkus.version>3.16.2</quarkus.version>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus-ide-config.version>3.14.4</quarkus-ide-config.version>
+        <quarkus-ide-config.version>3.16.2</quarkus-ide-config.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>


### PR DESCRIPTION
Bumping Quarkus to 3.16.2, as this is bigger bump let's see what CI is thinking about it. If there are failiures I'll look at them in some free time this week.