### PR TITLE
Update dependabot.yml to set maven package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "maven" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"


### PR DESCRIPTION
Update dependabot.yml to set maven package ecosystem

This should make https://github.com/quarkus-qe/quarkus-startstop/network/updates > Dependabot working