### PR TITLE
[3.15] Use code.quarkus.redhat.com and the latest version of Quarkus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>3.14.4</quarkus.version>
+        <quarkus.version>3.15.1</quarkus.version>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus-ide-config.version>3.15.0.CR1</quarkus-ide-config.version>
+        <quarkus-ide-config.version>3.15.1</quarkus-ide-config.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -184,7 +184,7 @@ public class Commands {
     }
 
     public static String getCodeQuarkusURL() {
-        return getCodeQuarkusURL("https://code.quarkus.io");
+        return getCodeQuarkusURL("https://code.quarkus.redhat.com");
     }
 
     public static String getCodeQuarkusURL(String fallbackURL) {


### PR DESCRIPTION
Doned because RHBQ 3.15.1 was released