### PR TITLE
Switch quarkus.platform.group-id to io.quarkus.platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
         <quarkus.version>3.17.7</quarkus.version>
-        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus-ide-config.version>3.17.8</quarkus-ide-config.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
Switch quarkus.platform.group-id to io.quarkus.platform

Should help with premature updates like https://github.com/quarkus-qe/quarkus-startstop/pull/460. We need platform releases.