### PR TITLE
Support for run command adjustments in StartStopTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ exercises some rudimentary business logic of selected extensions.
 `start-stop.cold-start` property - use cold start mode to drop OS page cache entries, dentries and inodes.
 - append for example `-Dstart-stop.cold-start` to the mvn command
 
+`start-stop.skip.threshold-check` property - skip checks against thresholds for RSS memory and time to first OK request
+- append for example `-Dstart-stop.skip.threshold-check` to the mvn command
+
+`start-stop.command.prefix` property - prefix the run command for the final Java and Native application, e.g. to limit CPU
+- append for example `-Dstart-stop.command.prefix="/opt/homebrew/bin/cpulimit -l 5 -i"` to the mvn command
+
+`start-stop.jvm.memory` property - configure memory limits for the run command for the final Java application
+- append for example `-Dstart-stop.jvm.memory=" -Xms256m -Xmx512m"` to the mvn command
+
+`start-stop.native.memory` property - configure memory limits for the run command for the final Native application
+- append for example `-Dstart-stop.native.memory="-Xms96m -Xmx96m"` to the mvn command
+
 Collect results:
 
 ```

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/MvnCmds.java
@@ -21,7 +21,7 @@ public enum MvnCmds {
     NATIVE(new String[][]{
             Stream.concat(Stream.of("mvn", "clean", "compile", "package", "-Pnative"),
                     getQuarkusNativeProperties().stream()).toArray(String[]::new),
-            new String[]{Commands.isThisWindows ? "target\\quarkus-runner.exe" : "./target/quarkus-runner", "-Xmx96m"}
+            new String[]{Commands.isThisWindows ? "target\\quarkus-runner.exe" : "./target/quarkus-runner"}
     }),
     GENERATOR(new String[][]{
             new String[]{

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/RunCommandAugmentor.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/RunCommandAugmentor.java
@@ -1,0 +1,38 @@
+package io.quarkus.ts.startstop.utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class RunCommandAugmentor {
+
+    public static List<String> setCommandPrefix(List<String> baseCommand, List<String> commandPrefix) {
+        if (commandPrefix == null || (commandPrefix.size() == 1 && commandPrefix.get(0).length() == 0)) {
+            return baseCommand;
+        }
+        List<String> runCmd = new ArrayList<>(baseCommand.size() + commandPrefix.size());
+        runCmd.addAll(commandPrefix);
+        for (String cmdPart : baseCommand) {
+            runCmd.add(cmdPart);
+        }
+        return Collections.unmodifiableList(runCmd);
+    }
+
+    public static List<String> setMemoryLimits(List<String> baseCommand, List<String> memory, boolean isNative) {
+        if (memory == null || (memory.size() == 1 && memory.get(0).length() == 0)) {
+            return baseCommand;
+        }
+        List<String> runCmd = new ArrayList<>(baseCommand.size() + memory.size());
+        for (String cmdPart : baseCommand) {
+            runCmd.add(cmdPart);
+            if (cmdPart.equals(Commands.JAVA_BIN)) {
+                runCmd.addAll(memory);
+            }
+        }
+        // for native command add memory at the end of the command
+        if (isNative) {
+            runCmd.addAll(memory);
+        }
+        return Collections.unmodifiableList(runCmd);
+    }
+}


### PR DESCRIPTION
Support for run command adjustments in StartStopTest

- `start-stop.skip.threshold-check` property - skip checks against thresholds for RSS memory and time to first OK request
  - append for example `-Dstart-stop.skip.threshold-check` to the mvn command



- `start-stop.command.prefix` property - prefix the run command for the final Java and Native application, e.g. to limit CPU
  - append for example `-Dstart-stop.command.prefix="/opt/homebrew/bin/cpulimit -l 5 -i"` to the mvn command



- `start-stop.jvm.memory` property - configure memory limits for the run command for the final Java application
  - append for example `-Dstart-stop.jvm.memory=" -Xms256m -Xmx512m"` to the mvn command



- `start-stop.native.memory` property - configure memory limits for the run command for the final Native application
  - append for example `-Dstart-stop.native.memory="-Xms96m -Xmx96m"` to the mvn command
