### PR TITLE
[3.20] Whitelist LatencyUtils for 3.20.0

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistProductBomJars.java
@@ -16,6 +16,8 @@ public enum WhitelistProductBomJars {
             // jna and jna-platform is dependency of io.quarkus:quarkus-jdbc-mariadb
             "net.java.dev.jna.jna",
             "net.java.dev.jna.jna-platform",
+            // TODO: whitelisted for 3.20.0, remove next line when https://issues.redhat.com/browse/QUARKUS-5937 is fixed
+            "org.latencyutils.LatencyUtils-2.0.3"
     });
 
     public final String[] jarNames;


### PR DESCRIPTION
Whitelisting LatencyUtils due to https://issues.redhat.com/browse/QUARKUS-5937 so that we can get jobs green.