### PR TITLE
Bump quarkus.version from 3.21.4 to 3.22.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>3.21.4</quarkus.version>
+        <quarkus.version>3.22.1</quarkus.version>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus-ide-config.version>3.22.1</quarkus-ide-config.version>
         <maven.compiler.source>17</maven.compiler.source>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -117,7 +117,7 @@ public class ArtifactGeneratorTest {
             "core",
             "hibernate-orm",
             "hibernate-orm-panache",
-            "hibernate-orm-rest-data-panache",
+//            "hibernate-orm-rest-data-panache",  see https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.22
             "hibernate-validator",
             "resteasy-client",
             "resteasy-client-jackson",
@@ -145,7 +145,7 @@ public class ArtifactGeneratorTest {
 //            "smallrye-reactive-messaging-amqp",
             "messaging-kafka",
             "spring-data-jpa",
-            "spring-data-rest",
+//            "spring-data-rest",  see https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.22
             "spring-di",
             "spring-security",
 //            "spring-web",  // spring-web-codestart uses quarkus-resteasy-reactive-jackson, see https://github.com/quarkusio/quarkus/pull/24890


### PR DESCRIPTION
 * Bump quarkus.version from 3.21.4 to 3.22.1
 * REST Data Panache modules no longer work with quarkus-resteasy modules