### PR TITLE
bump-to-3.20.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>3.20.0</quarkus.version>
+        <quarkus.version>3.20.1</quarkus.version>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus-ide-config.version>3.20.0</quarkus-ide-config.version>
+        <quarkus-ide-config.version>3.20.1</quarkus-ide-config.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -79,7 +79,7 @@ public enum WhitelistLogLines {
             // https://github.com/quarkusio/quarkus/pull/28810
             Pattern.compile(".*Stream is closed, ignoring and trying to continue.*"),
             // https://github.com/quarkusio/quarkus/pull/28654
-            Pattern.compile(".*Using legacy gRPC support, with separate new HTTP server instance. Switch to single HTTP server instance usage with quarkus.grpc.server.use-separate-server=false property.*"),
+            Pattern.compile(".*Using legacy gRPC support.*separate.*HTTP server instance.*"),
             // Full stack trace switch enabled for dev mode command
             Pattern.compile(".*Error stacktraces are turned on.*"),
             // arquillian-bom has wrong sha1 and md5sum, discussed with jfang who uploaded it, there is nothing he can do about it


### PR DESCRIPTION
Version upgrade in POM file :
```
<quarkus.version>3.20.1</quarkus.version>
 <quarkus-ide-config.version>3.20.1</quarkus-ide-config.version>

```