### PR TITLE
Bump versions to 3.20.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
     <packaging>pom</packaging>
     <name>Quarkus StartStop TS: Parent</name>
     <properties>
-        <quarkus.version>3.20.1</quarkus.version>
+        <quarkus.version>3.20.2</quarkus.version>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus-ide-config.version>3.20.1</quarkus-ide-config.version>
+        <quarkus-ide-config.version>3.20.2</quarkus-ide-config.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>


### PR DESCRIPTION
Bump versions to 3.20.2
`
<quarkus.version>3.20.2</quarkus.version>
<quarkus-ide-config.version>3.20.2</quarkus-ide-config.version>
`