### PR TITLE
Change of the supported flag XPath

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -48,7 +48,7 @@ public class CodeQuarkusSiteTest {
     public static final String elementRedHatLogoByXpath= "//img[@class=\"logo\"][@alt=\"Red Hat Logo\"]";
     public static final String elementStreamPickerByXpath= "//div[@class=\"stream-picker dropdown\"]";
     public static final String elementStreamItemsByXpath= "//div[@class=\"dropdown-item\"]";
-    public static final String elementSupportedFlagByXpath = "//div[@class=\"extension-tag redhat-support-supported dropdown-toggle\"]";
+    public static final String elementSupportedFlagByXpath = "//div[@class=\"extension-tag support-full-support dropdown-toggle\"]";
     public static final String elementQuarkusPlatformVersionByXpath = "//div[contains(@class, 'quarkus-stream')]";
 
     private BrowserContext browserContext; // Operates in incognito mode


### PR DESCRIPTION
The supported tag was changed few days ago, when adding the support to ibm and u[dating the code.quarkus.

To do it more universal, the <support-scope>:<support-level> (redhat-support:tech-preview) was transformed to support:<support-level> (support:tech-preview).

Only one which changing the support level name is supported level. It's transformed to full-support. This can be found in https://github.com/redhat-developer/code.quarkus.redhat.com/blob/main/src/main/java/OfferingPlatformOverride.java#L76

The all tags can be found in https://github.com/redhat-developer/code.quarkus.redhat.com/blob/main/src/main/resources/web/redhat-app/index.jsx#L12

Also this will need backported. I'll do it for all supported streams after this is merged