### PR TITLE
Whitelist protobuf error line

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -188,6 +188,9 @@ public enum WhitelistLogLines {
             Pattern.compile(".*Cross-Origin Resource Sharing \\(CORS\\) filter must be enabled for Streamable HTTP MCP server endpoints.*"),
             // GH Actions Windows runners and Netty DNS config warning
             Pattern.compile(".*DefaultDnsServerAddressStreamProvider.*Google Public DNS as a fallback.*"),
+            // CSD jenkins include env property JAVA_TOOL_OPTIONS: -Dmaven.ext.class.path=... which gets picket by protobuf
+            // but the property itself is on different line, so cannot be checked for
+            Pattern.compile(".*com.google.protobuf-protoc.*completed but logged errors.*"),
     }),
     // Quarkus is not being gratefully shutdown in Windows when running in Dev mode.
     // Reported by https://github.com/quarkusio/quarkus/issues/14647.


### PR DESCRIPTION
On CSD jenkins a lot of tests are failing on warning like:
```
[WARNING] [io.smallrye.common.process] SRCOM05000: Command /tmp/quarkusBomReactiveExtensionsA/app-generated-skeleton/target/com.google.protobuf-protoc-linux-x86_64-exe (pid 12064) completed but logged errors:
	Picked up JAVA_TOOL_OPTIONS: -Dmaven.ext.class.path=...<whatever>...
```
The `JAVA_TOOL_OPTIONS` option has a legitimate use in that env, so we cannot easily remove it.

I didn't find a better way to fix this and also to whitelist this as the `[Warning]` is on different line as the actual reported variable.