### PR TITLE
[3.27] Fixing elementSupportedFlagByXpath after recent update of code.quarkus

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ibm/CodeQuarkusIbmSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ibm/CodeQuarkusIbmSiteTest.java
@@ -41,7 +41,7 @@ public class CodeQuarkusIbmSiteTest {
     public static final String elementBrandNameByXpath = "//div[@class=\"brand\" and contains(text(), 'Enterprise Build of Quarkus')]";
     public static final String elementStreamPickerByXpath = "//div[@class=\"stream-picker dropdown\"]";
     public static final String elementStreamItemsByXpath = "//div[@class=\"dropdown-item\"]";
-    public static final String elementSupportedFlagByXpath = "//div[@class=\"extension-tag support-full-support dropdown-toggle\"]";
+    public static final String elementSupportedFlagByXpath = "//div[@class=\"extension-tag support-full-support extension-tag-full-name dropdown-toggle\"]";
     public static final String elementQuarkusPlatformVersionByXpath = "//div[contains(@class, 'quarkus-stream')]";
     public static final String elementExtensionByXpath = "//div[@class=\"extension-row\" and @aria-label=\"%s\"]";
     public static final String elementSupportFilterXpath = "//div[@class='filter-combo-button dropdown-toggle' and @aria-label=\"Toggle support combobox\"]";

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/redhat/CodeQuarkusRedHatSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/redhat/CodeQuarkusRedHatSiteTest.java
@@ -41,7 +41,7 @@ public class CodeQuarkusRedHatSiteTest {
     public static final String elementRedHatLogoByXpath = "//img[@class=\"logo\"][@alt=\"Red Hat Logo\"]";
     public static final String elementStreamPickerByXpath = "//div[@class=\"stream-picker dropdown\"]";
     public static final String elementStreamItemsByXpath = "//div[@class=\"dropdown-item\"]";
-    public static final String elementSupportedFlagByXpath = "//div[@class=\"extension-tag support-full-support dropdown-toggle\"]";
+    public static final String elementSupportedFlagByXpath = "//div[@class=\"extension-tag support-full-support extension-tag-full-name dropdown-toggle\"]";
     public static final String elementQuarkusPlatformVersionByXpath = "//div[contains(@class, 'quarkus-stream')]";
     public static final String elementExtensionByXpath = "//div[@class=\"extension-row\" and @aria-label=\"%s\"]";
     public static final String elementSupportFilterXpath = "//div[@class='filter-combo-button dropdown-toggle' and @aria-label=\"Toggle support combobox\"]";


### PR DESCRIPTION
Fixing elementSupportedFlagByXpath after recent update of code.quarkus

(cherry picked from commit https://github.com/quarkus-qe/quarkus-startstop/commit/665eef9f5a6194192039e7da18a2f72f0d400ac3)