### PR TITLE
Increase devmode timeout from 120s to 180s

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/SpecialCharsTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/SpecialCharsTest.java
@@ -134,7 +134,7 @@ public class SpecialCharsTest {
 
             // Test web page
             LOGGER.info("Testing web page content...");
-            int timeout = mvnCmds != MvnCmds.DEV ? 30 : 120;
+            int timeout = mvnCmds != MvnCmds.DEV ? 30 : 180;
             for (String[] urlContent : app.urlContent.urlContent) {
                 WebpageTester.testWeb(urlContent[0], timeout, urlContent[1], false);
             }


### PR DESCRIPTION
Increasing the devmode timeout from 120s to 180s. In 3.33 I spotted that sometime (on aarch64 all the time) `diacriticsDEV` fail. Looking at log it timeout  when downloading the dependencies. As we moved to to new nexus this is probably caused by this. The `diacriticsDEV` run all the time first and the tests use same local maven repository, so next tests won't fail.

Maybe as follow up of this PR we should do `mvn dependency:resolve` before running the dev mode. 