### PR TITLE
Accept updates in tests

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/QuarkusMavenPluginTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/QuarkusMavenPluginTest.java
@@ -69,6 +69,11 @@ public class QuarkusMavenPluginTest {
 
             List<String> baseBuildCmd = new ArrayList<>();
             baseBuildCmd.addAll(Arrays.asList("mvn", "clean", "quarkus:" + goalName));
+            if (goalName.equals("update")) {
+                // quarkus:update goal requires confirmation that you want to apply the updates (you must interactively type Y).
+                // This option should force it to apply the updates without confirmation.
+                baseBuildCmd.add("-Drewrite");
+            }
             baseBuildCmd.add("-Dquarkus.version=" + getQuarkusVersion());
             baseBuildCmd.add("-Dquarkus.platform.group-id=" + getQuarkusGroupId());
             List<String> cmd = getBuildCommand(baseBuildCmd.toArray(new String[0]));


### PR DESCRIPTION
When execution goal `quarkus:update` the process will ask, if the updates should be applied and then is waiting for confirmation.
Currently it will just hang until timeout and the test will consider it passed since the log still contains `BUILD SUCCESS` substring

This PR is changing the behaviour to "accept" the updates via CLI option