### PR TITLE
Check the streams selection presence, not the number of defined streams

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ibm/CodeQuarkusIbmSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ibm/CodeQuarkusIbmSiteTest.java
@@ -126,13 +126,6 @@ public class CodeQuarkusIbmSiteTest {
         streamPicker.click();
         Locator streamItems = page.locator(elementStreamItemsByXpath);
         assertTrue(streamItems.count() > 0, "No stream is defined");
-        /*
-        TODO enable this when there is more then 1 stream. Atm only 3.27 will be available
-        if (!webPageUrl.contains("apps.ocp-c1")) {  // build-scoped instances have just the current stream defined
-            assertTrue(streamItems.count() > 1, "Two (or more) streams are expected to be defined defined, streamItems count: " + streamItems.count() + "\n" +
-                    "Product Update and Support Policy: https://access.redhat.com/support/policy/updates/jboss_notes#p_quarkus");
-        }
-        */
     }
 
     @Test

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/redhat/CodeQuarkusRedHatSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/redhat/CodeQuarkusRedHatSiteTest.java
@@ -126,8 +126,6 @@ public class CodeQuarkusRedHatSiteTest {
         streamPicker.click();
         Locator streamItems = page.locator(elementStreamItemsByXpath);
         assertTrue(streamItems.count() > 0, "No stream is defined");
-        assertTrue(streamItems.count() > 1, "Two (or more) streams are expected to be defined defined, streamItems count: " + streamItems.count() + "\n" +
-                "Product Update and Support Policy: https://access.redhat.com/support/policy/updates/jboss_notes#p_quarkus");
     }
 
     @Test


### PR DESCRIPTION
Check the streams selection presence, not the number of defined streams

Testing instances have just one stream defined and the infrastructure is changing a lot (2 different URLs on RH side, something new on IBM side), so no simple way to differentiate testing and prod instances