### PR TITLE
Ensure streams selection has at least 2 items

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ibm/CodeQuarkusIbmSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ibm/CodeQuarkusIbmSiteTest.java
@@ -126,6 +126,9 @@ public class CodeQuarkusIbmSiteTest {
         streamPicker.click();
         Locator streamItems = page.locator(elementStreamItemsByXpath);
         assertTrue(streamItems.count() > 0, "No stream is defined");
+        assertTrue(streamItems.count() > 1, "Two (or more) streams are expected to be defined defined, streamItems count: " + streamItems.count() + "\n" +
+                "Production instances have at least 2 streams, because product offerings have 2 active streams\n" +
+                "Testing instances need to have at least 2 streams, because CLI update scenarios from previous LTS need to be tested.");
     }
 
     @Test

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/redhat/CodeQuarkusRedHatSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/redhat/CodeQuarkusRedHatSiteTest.java
@@ -126,6 +126,9 @@ public class CodeQuarkusRedHatSiteTest {
         streamPicker.click();
         Locator streamItems = page.locator(elementStreamItemsByXpath);
         assertTrue(streamItems.count() > 0, "No stream is defined");
+        assertTrue(streamItems.count() > 1, "Two (or more) streams are expected to be defined defined, streamItems count: " + streamItems.count() + "\n" +
+                "Production instances have at least 2 streams, because product offerings have 2 active streams\n" +
+                "Testing instances need to have at least 2 streams, because CLI update scenarios from previous LTS need to be tested.");
     }
 
     @Test


### PR DESCRIPTION
Ensure streams selection has at least 2 items

Kind of revert of https://github.com/quarkus-qe/quarkus-startstop/pull/766/

Adding more context for testing instances, 2+ streams are needed to be able to run CLI update scenarios. We faces those issues with product build testing for 3.33.2 and 3.37.4 when we had just one stream defined and it became blocker.