### PR TITLE
[3.20] Fixing elementSupportedFlagByXpath after recent update of code.quarkus

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusSiteTest.java
@@ -48,7 +48,7 @@ public class CodeQuarkusSiteTest {
     public static final String elementRedHatLogoByXpath= "//img[@class=\"logo\"][@alt=\"Red Hat Logo\"]";
     public static final String elementStreamPickerByXpath= "//div[@class=\"stream-picker dropdown\"]";
     public static final String elementStreamItemsByXpath= "//div[@class=\"dropdown-item\"]";
-    public static final String elementSupportedFlagByXpath = "//div[@class=\"extension-tag support-full-support dropdown-toggle\"]";
+    public static final String elementSupportedFlagByXpath = "//div[@class=\"extension-tag support-full-support extension-tag-full-name dropdown-toggle\"]";
     public static final String elementQuarkusPlatformVersionByXpath = "//div[contains(@class, 'quarkus-stream')]";
 
     private BrowserContext browserContext; // Operates in incognito mode


### PR DESCRIPTION
Custom variant of https://github.com/quarkus-qe/quarkus-startstop/pull/751 as 3.20 doesn't have IBM counterpart