### PR TITLE
Whitelist warning about docker cgroups v1

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -48,6 +48,8 @@ public enum WhitelistLogLines {
             Pattern.compile(".*The Maven extensions for the Quarkus Maven plugin are not enabled for this build.*"),
             // TODO remove this when https://github.com/quarkusio/quarkus/issues/41016#issuecomment-3847062608 is fixed
             Pattern.compile(".*Option 'DynamicProxyConfigurationResources' is deprecated and might be removed in a future release.*"),
+            // RHEL 8 uses docker cgroups v1 by default, those are considered deprecated in native build
+            Pattern.compile(".*Support for cgroup v1 is deprecated and planned to be removed.*"),
     }),
     FULL_MICROPROFILE(new Pattern[]{
             // Some artifacts names...


### PR DESCRIPTION
On CSD, RHEL 8 used docker cgroups v1 by default (with no feasable way to upgrade to v2). That is considered deprecated in quarkus native builds in https://github.com/moby/moby/issues/51111

As there is no real way to fix this warning, I'm whitelisting it. Main reason is to backport this into 3.27, where we still use RHEL 8. This is not a problem on RHEL 9 as that one is using cgroups v2 by default.
