### PR TITLE
Stop using empty settings file

### DIFF
--- a/app-generated-skeleton/settings.xml
+++ b/app-generated-skeleton/settings.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-    <!-- This an empty settings.xml to avoid any local surpises -->
+<settings>
+    <mirrors>
+        <mirror>
+            <id>google-maven-central</id>
+            <name>GCS Maven Central mirror</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+            <mirrorOf>central</mirrorOf>
+        </mirror>
+    </mirrors>
 </settings>


### PR DESCRIPTION
Maven central added strict download limits and now startstop jobs are failing on Jenkins Jenkins nodes has local settings, which point to a mirror, so it make sense to use these these