### PR TITLE
[3.33] Use Google maven mirror during product testing

### DIFF
--- a/app-generated-skeleton/settings.xml
+++ b/app-generated-skeleton/settings.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-    <!-- This an empty settings.xml to avoid any local surpises -->
+<settings>
+    <mirrors>
+        <mirror>
+            <id>google-maven-central</id>
+            <name>GCS Maven Central mirror</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+            <mirrorOf>central</mirrorOf>
+        </mirror>
+    </mirrors>
 </settings>


### PR DESCRIPTION
Previously, we used empty settings for product testing, and it caused failures due to rate-limiting

backport of https://github.com/quarkus-qe/quarkus-startstop/pull/801