### PR TITLE
Whitelist docker failure about cgroups v1

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -49,6 +49,7 @@ public enum WhitelistLogLines {
             // TODO remove this when https://github.com/quarkusio/quarkus/issues/41016#issuecomment-3847062608 is fixed
             Pattern.compile(".*Option 'DynamicProxyConfigurationResources' is deprecated and might be removed in a future release.*"),
             // RHEL 8 uses docker cgroups v1 by default, those are considered deprecated in native build
+            Pattern.compile(".*Command docker \\(pid .*\\) completed but logged error.*"),
             Pattern.compile(".*Support for cgroup v1 is deprecated and planned to be removed.*"),
     }),
     FULL_MICROPROFILE(new Pattern[]{


### PR DESCRIPTION
This PR follows up on https://github.com/quarkus-qe/quarkus-startstop/pull/799 as whitelisting just the error message itself is now sufficient.
The whole failure produces a message:
```
[WARNING] [io.smallrye.common.process] SRCOM05000: Command docker (pid *****) completed but logged errors:
	WARNING: Support for cgroup v1 is deprecated and planned to be removed by no later than May 2029 (https://github.com/moby/moby/issues/51111)
```
Ignoring just the `Support for cgroups v1 ...` part is not sufficient as our test also considers the `Command docker (pid *****) completed but logged errors` as problematic enough to fail the test. That is why I'm also adding this to the whitelisted lines.

I tried to make this line specific to docker failures, so it will not accidentally whitelist something else. Also the line `Command docker (pid *****) completed but logged errors` should always be followed by another line, with the failure itself, so this should not ignore any other failure.