### PR TITLE
[3.27] Whitelist docker failure

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -23,6 +23,7 @@ public enum WhitelistLogLines {
             Pattern.compile(".*Warning: The option '-H:ReflectionConfigurationResources=META-INF/native-image/io\\.netty/netty-transport/reflection-config\\.json' is experimental and must be enabled via.*"),
             Pattern.compile(".*Unrecognized configuration key \"quarkus.version\" was provided.*"),
             // RHEL 8 uses docker cgroups v1 by default, those are considered deprecated in native build
+            Pattern.compile(".*Command docker \\(pid .*\\) completed.*but logged.*err.*"),
             Pattern.compile(".*Support for cgroup v1 is deprecated and planned to be removed.*"),
     }),
     FULL_MICROPROFILE(new Pattern[]{


### PR DESCRIPTION
Backport https://github.com/quarkus-qe/quarkus-startstop/pull/804 into 3.27

Also takes into account change in the Pattern to match both variants of error message - see https://github.com/smallrye/smallrye-common/commit/1e38a47943f8d3c6c623778a3baa858007b05e84