### PR TITLE
Entry to ignore Quarkus issue #55835

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WhitelistLogLines.java
@@ -197,6 +197,9 @@ public enum WhitelistLogLines {
             // CSD jenkins include env property JAVA_TOOL_OPTIONS: -Dmaven.ext.class.path=... which gets picket by protobuf
             // but the property itself is on different line, so cannot be checked for
             Pattern.compile(".*com.google.protobuf-protoc.*completed but logged errors.*"),
+            // TODO remove this when https://github.com/quarkusio/quarkus/issues/55835 is fixed
+            Pattern.compile(".*A restricted method in java.lang.foreign.Linker has been called.*"),
+            Pattern.compile(".*java.lang.foreign.Linker::downcallHandle has been called by org.aesh.terminal.tty.impl.LibC in an unnamed module.*"),
     }),
     // Quarkus is not being gratefully shutdown in Windows when running in Dev mode.
     // Reported by https://github.com/quarkusio/quarkus/issues/14647.


### PR DESCRIPTION
Entry to ignore Quarkus issue #55835

https://github.com/quarkusio/quarkus/issues/55835

Daily runs are affected by this as code.quarkus moved to 3.38
(e.g. https://github.com/quarkus-qe/quarkus-startstop/actions/runs/30732324279/job/91454788988)