### PR TITLE
[3.40] Add stream to download url

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -327,7 +327,8 @@ public class Commands {
      */
     public static String download(Collection<CodeQuarkusExtensions> extensions, String destinationZipFile) throws IOException {
         String downloadURL = getCodeQuarkusURL() + "/api/download?" +
-                extensions.stream().map(x -> "e=" + x.id).collect(Collectors.joining("&"));
+                extensions.stream().map(x -> "e=" + x.id).collect(Collectors.joining("&")) +
+                "&S=3.40";
         return download(downloadURL, destinationZipFile);
     }
 
@@ -349,7 +350,7 @@ public class Commands {
     public static String download(Collection<CodeQuarkusExtensions> extensions, String destinationZipFile, int javaVersion) throws IOException {
         String downloadURL = getCodeQuarkusURL() + "/api/download?" +
                 extensions.stream().map(x -> "e=" + x.id).collect(Collectors.joining("&")) +
-                "&j=" + javaVersion;
+                "&j=" + javaVersion + "&S=3.40";
         return download(downloadURL, destinationZipFile);
     }
 


### PR DESCRIPTION
This needs to wail a little as for downloads we using code.quarkus.io which don't have 3.40 stream yet. Not having this should not affect initial testing as by default code.quarkus set the newest stream which will be 3.39/3.40