### PR TITLE
disable the remaining native test on Windows directly

### DIFF
--- a/testsuite/src/it/java/io/quarkus/ts/startstop/SpecialCharsTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/SpecialCharsTest.java
@@ -172,6 +172,7 @@ public class SpecialCharsTest {
 
     @Test
     @Tag("native")
+    @DisabledOnOs(value = {OS.WINDOWS}, disabledReason = "Native on Windows is not supported")
     public void spacesNative(TestInfo testInfo) throws IOException, InterruptedException {
         testRuntime(testInfo, Apps.JAKARTA_REST_MINIMAL, MvnCmds.NATIVE, "s p a c e s n a t i v e");
     }


### PR DESCRIPTION
All native tests are disabled on Windows, except this one. Let's disable it as well to improve consistency and make test execution a little easier.