### PR TITLE
[3.40] improve timeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,16 @@ The need for async-profiler is assumed just for StartStopTest at this stage, see
 
 Ensure the system is prepared for async-profiler executions preventing unexpected warnings, details are mentioned in the above linked `TROUBLESHOOTING.md document.
 
+## Timeout scaling
+
+This test suite supports simple timeout scaling. On multiple places, the `Timeout` class is used to represent timeout
+values. This class multiplies the given value with the value of the `ts.timeout.multiplier` system property and uses
+the result as the actual timeout.
+
+To run tests with 4x longer timeouts, pass `-Dts.timeout.multiplier=4`.
+
+You can also pass a fraction if you want shorter timeouts: `-Dts.timeout.multiplier=0.5`.
+
 ## Windows notes
 
 ### Note on Native image

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorBOMTest.java
@@ -4,6 +4,7 @@ import io.quarkus.ts.startstop.utils.Apps;
 import io.quarkus.ts.startstop.utils.Commands;
 import io.quarkus.ts.startstop.utils.MvnCmds;
 import io.quarkus.ts.startstop.utils.TestFlags;
+import io.quarkus.ts.startstop.utils.Timeout;
 import io.quarkus.ts.startstop.utils.URLContent;
 import io.quarkus.ts.startstop.utils.WebpageTester;
 import org.apache.commons.lang3.StringUtils;
@@ -94,7 +95,7 @@ public class ArtifactGeneratorBOMTest {
             LOGGER.info(mn + ": Generator command " + String.join(" ", generatorCmd));
             generateLog = new File(logsDir + File.separator + "bom-artifact-generator.log");
             ExecutorService buildService = Executors.newFixedThreadPool(1);
-            buildService.submit(new Commands.ProcessRunner(appBaseDir, generateLog, generatorCmd, 20));
+            buildService.submit(new Commands.ProcessRunner(appBaseDir, generateLog, generatorCmd, Timeout.ofMinutes(20)));
             appendln(whatIDidReport, "# " + cn + ", " + mn);
             appendln(whatIDidReport, (new Date()).toString());
             appendln(whatIDidReport, appBaseDir.getAbsolutePath());
@@ -119,7 +120,7 @@ public class ArtifactGeneratorBOMTest {
             LOGGER.info(mn + ": Build command " + String.join(" ", buildCmd));
             buildLogA = new File(logsDir + File.separator + "bom-artifact-build.log");
             buildService = Executors.newFixedThreadPool(1);
-            buildService.submit(new Commands.ProcessRunner(appDir, buildLogA, buildCmd, 20));
+            buildService.submit(new Commands.ProcessRunner(appDir, buildLogA, buildCmd, Timeout.ofMinutes(20)));
             appendln(whatIDidReport, appDir.getAbsolutePath());
             appendlnSection(whatIDidReport, String.join(" ", buildCmd));
             buildService.shutdown();
@@ -137,7 +138,7 @@ public class ArtifactGeneratorBOMTest {
             pA = runCommand(runCmd, appDir, runLogA);
 
             // Test web pages
-            WebpageTester.testWeb(skeletonApp.urlContent[0][0], 20,
+            WebpageTester.testWeb(skeletonApp.urlContent[0][0], Timeout.ofSeconds(20),
                     skeletonApp.urlContent[0][1], false);
 
             LOGGER.info("Terminating test and scanning logs...");
@@ -146,7 +147,7 @@ public class ArtifactGeneratorBOMTest {
             processStopper(pA, false);
             LOGGER.info("Gonna wait for ports closed after run...");
             // Release ports
-            assertTrue(waitForTcpClosed("localhost", parsePort(skeletonApp.urlContent[0][0]), 60),
+            assertTrue(waitForTcpClosed("localhost", parsePort(skeletonApp.urlContent[0][0]), Timeout.ofMinutes(1)),
                     "Main port is still open after run");
 
             checkLog(cn, mn, Apps.GENERATED_SKELETON, MvnCmds.JVM, runLogA);

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ArtifactGeneratorTest.java
@@ -50,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.quarkus.ts.startstop.utils.Timeout;
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -314,7 +315,7 @@ public class ArtifactGeneratorTest {
             // Build
             buildLogA = new File(logsDir + File.separator + (flags.contains(TestFlags.WARM_UP) ? "warmup-artifact-build.log" : "artifact-build.log"));
             ExecutorService buildService = Executors.newFixedThreadPool(1);
-            buildService.submit(new Commands.ProcessRunner(appBaseDir, buildLogA, generatorCmd, 20));
+            buildService.submit(new Commands.ProcessRunner(appBaseDir, buildLogA, generatorCmd, Timeout.ofMinutes(20)));
             appendln(whatIDidReport, "# " + cn + ", " + mn + ", warmup run: " + flags.contains(TestFlags.WARM_UP));
             appendln(whatIDidReport, (new Date()).toString());
             appendln(whatIDidReport, appBaseDir.getAbsolutePath());
@@ -345,8 +346,8 @@ public class ArtifactGeneratorTest {
             pA = runCommand(runCmd, appDir, runLogA);
             // Test web pages
             // The reason for a seemingly large timeout of 20 minutes is that dev mode will be downloading the Internet on the first fresh run.
-            long timeoutS = (flags.contains(TestFlags.WARM_UP) ? 20 * 60 : 120);
-            long timeToFirstOKRequest = WebpageTester.testWeb(skeletonApp.urlContent[0][0], timeoutS,
+            Timeout timeout = flags.contains(TestFlags.WARM_UP) ? Timeout.ofMinutes(20) : Timeout.ofMinutes(2);
+            long timeToFirstOKRequest = WebpageTester.testWeb(skeletonApp.urlContent[0][0], timeout,
                     skeletonApp.urlContent[0][1], !flags.contains(TestFlags.WARM_UP));
 
             if (flags.contains(TestFlags.WARM_UP)) {
@@ -355,7 +356,7 @@ public class ArtifactGeneratorTest {
                 processStopper(pA, false);
                 LOGGER.info("Gonna wait for ports closed after warmup...");
                 // Release ports
-                assertTrue(waitForTcpClosed("localhost", parsePort(skeletonApp.urlContent[0][0]), 60),
+                assertTrue(waitForTcpClosed("localhost", parsePort(skeletonApp.urlContent[0][0]), Timeout.ofMinutes(1)),
                         "Main port is still open after warmup");
                 checkLog(cn, mn, Apps.GENERATED_SKELETON, MvnCmds.GENERATOR, runLogA);
                 return;
@@ -372,8 +373,10 @@ public class ArtifactGeneratorTest {
 
             // test modified class and measure time
             long timeToReloadedOKRequest = WebpageTester.testWeb(
-                    flags.contains(TestFlags.RESTEASY_REACTIVE)?skeletonApp.urlContent[3][0]:skeletonApp.urlContent[1][0], 60,
-                    flags.contains(TestFlags.RESTEASY_REACTIVE)?skeletonApp.urlContent[3][1]:skeletonApp.urlContent[1][1], true);
+                    flags.contains(TestFlags.RESTEASY_REACTIVE)?skeletonApp.urlContent[3][0]:skeletonApp.urlContent[1][0],
+                    Timeout.ofMinutes(1),
+                    flags.contains(TestFlags.RESTEASY_REACTIVE)?skeletonApp.urlContent[3][1]:skeletonApp.urlContent[1][1],
+                    true);
 
             // add new class
             Path addedFile = Paths
@@ -383,7 +386,7 @@ public class ArtifactGeneratorTest {
             copyFileForSkeleton("AddedController.java", addedFile);
 
             // test added class
-            WebpageTester.testWeb(skeletonApp.urlContent[2][0], 60, skeletonApp.urlContent[2][1], false);
+            WebpageTester.testWeb(skeletonApp.urlContent[2][0], Timeout.ofMinutes(1), skeletonApp.urlContent[2][1], false);
 
             LOGGER.info("Terminate and scan logs...");
             pA.getInputStream().available();
@@ -395,7 +398,7 @@ public class ArtifactGeneratorTest {
 
             LOGGER.info("Gonna wait for ports closed...");
             // Release ports
-            assertTrue(waitForTcpClosed("localhost", parsePort(skeletonApp.urlContent[0][0]), 60),
+            assertTrue(waitForTcpClosed("localhost", parsePort(skeletonApp.urlContent[0][0]), Timeout.ofMinutes(1)),
                     "Main port is still open");
             checkLog(cn, mn, Apps.GENERATED_SKELETON, MvnCmds.GENERATOR, runLogA);
 

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/CodeQuarkusTest.java
@@ -4,6 +4,7 @@ import io.quarkus.ts.startstop.utils.Apps;
 import io.quarkus.ts.startstop.utils.CodeQuarkusExtensions;
 import io.quarkus.ts.startstop.utils.Commands;
 import io.quarkus.ts.startstop.utils.MvnCmds;
+import io.quarkus.ts.startstop.utils.Timeout;
 import io.quarkus.ts.startstop.utils.URLContent;
 import io.quarkus.ts.startstop.utils.WebpageTester;
 
@@ -123,7 +124,7 @@ public class CodeQuarkusTest {
                 appendlnSection(whatIDidReport, String.join(" ", cmd));
 
                 LOGGER.info("Building (" + cmd + ")");
-                buildService.submit(new Commands.ProcessRunner(appDir, buildLogA, cmd, 20));
+                buildService.submit(new Commands.ProcessRunner(appDir, buildLogA, cmd, Timeout.ofMinutes(20)));
 
                 buildService.shutdown();
                 buildService.awaitTermination(30, TimeUnit.MINUTES);
@@ -147,14 +148,14 @@ public class CodeQuarkusTest {
             pA = runCommand(cmd, appDir, runLogA);
 
             // It takes time to download the Internet
-            long timeoutS = 10 * 60;
-            LOGGER.info("Timeout: " + timeoutS + "s. Waiting for the web content...");
-            WebpageTester.testWeb(skeletonApp.urlContent[0][0], timeoutS, skeletonApp.urlContent[0][1], false);
+            Timeout timeout = Timeout.ofMinutes(10);
+            LOGGER.info("Timeout: " + timeout + ". Waiting for the web content...");
+            WebpageTester.testWeb(skeletonApp.urlContent[0][0], timeout, skeletonApp.urlContent[0][1], false);
             LOGGER.info("Terminating and scanning logs...");
             pA.getInputStream().available();
             processStopper(pA, false);
             LOGGER.info("Gonna wait for ports closed...");
-            assertTrue(waitForTcpClosed("localhost", parsePort(skeletonApp.urlContent[0][0]), 60),
+            assertTrue(waitForTcpClosed("localhost", parsePort(skeletonApp.urlContent[0][0]), Timeout.ofMinutes(1)),
                     "Main port is still open.");
             checkLog(cn, mn, Apps.GENERATED_SKELETON, mvnCmds, runLogA);
             checkListeningHost(cn, mn, mvnCmds, runLogA);

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/NativeDebugTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/NativeDebugTest.java
@@ -3,6 +3,7 @@ package io.quarkus.ts.startstop;
 import io.quarkus.ts.startstop.utils.Apps;
 import io.quarkus.ts.startstop.utils.MvnCmds;
 import io.quarkus.ts.startstop.utils.Commands;
+import io.quarkus.ts.startstop.utils.Timeout;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -68,7 +69,7 @@ public class NativeDebugTest {
             List<String> cmd = getBuildCommand(baseBuildCmd.toArray(new String[0]));
 
             LOGGER.info("Building (" + cmd + ")");
-            buildService.submit(new Commands.ProcessRunner(appDir, buildLogA, cmd, 20));
+            buildService.submit(new Commands.ProcessRunner(appDir, buildLogA, cmd, Timeout.ofMinutes(20)));
             buildService.shutdown();
             buildService.awaitTermination(30, TimeUnit.MINUTES);
 

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/QuarkusMavenPluginTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/QuarkusMavenPluginTest.java
@@ -2,6 +2,7 @@ package io.quarkus.ts.startstop;
 
 import io.quarkus.ts.startstop.utils.Apps;
 import io.quarkus.ts.startstop.utils.Commands;
+import io.quarkus.ts.startstop.utils.Timeout;
 import org.apache.commons.io.FileUtils;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Tag;
@@ -80,7 +81,7 @@ public class QuarkusMavenPluginTest {
 
             LOGGER.info("Running " + String.join(" ",cmd) +" in " + appDestDir);
 
-            buildService.submit(new Commands.ProcessRunner(appDestDir, logFile, cmd, 5));
+            buildService.submit(new Commands.ProcessRunner(appDestDir, logFile, cmd, Timeout.ofMinutes(5)));
             appendln(whatIDidReport, "# " + cn + ", " + mn);
             appendln(whatIDidReport, (new Date()).toString());
             appendln(whatIDidReport, appDestDir.getAbsolutePath());

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/SpecialCharsTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/SpecialCharsTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 import io.quarkus.ts.startstop.utils.Apps;
 import io.quarkus.ts.startstop.utils.Commands;
 import io.quarkus.ts.startstop.utils.MvnCmds;
+import io.quarkus.ts.startstop.utils.Timeout;
 import io.quarkus.ts.startstop.utils.WebpageTester;
 import org.apache.commons.io.FileUtils;
 import org.jboss.logging.Logger;
@@ -106,7 +107,7 @@ public class SpecialCharsTest {
                 appendlnSection(whatIDidReport, String.join(" ", cmd));
 
                 LOGGER.info("Building (" + cmd + ")");
-                buildService.submit(new Commands.ProcessRunner(appDir, buildLogA, cmd, 20));
+                buildService.submit(new Commands.ProcessRunner(appDir, buildLogA, cmd, Timeout.ofMinutes(20)));
 
                 buildService.shutdown();
                 buildService.awaitTermination(30, TimeUnit.MINUTES);
@@ -134,7 +135,7 @@ public class SpecialCharsTest {
 
             // Test web page
             LOGGER.info("Testing web page content...");
-            int timeout = mvnCmds != MvnCmds.DEV ? 30 : 180;
+            Timeout timeout = mvnCmds != MvnCmds.DEV ? Timeout.ofSeconds(30) : Timeout.ofMinutes(3);
             for (String[] urlContent : app.urlContent.urlContent) {
                 WebpageTester.testWeb(urlContent[0], timeout, urlContent[1], false);
             }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/StartStopTest.java
@@ -7,6 +7,7 @@ import io.quarkus.ts.startstop.utils.LogBuilder;
 import io.quarkus.ts.startstop.utils.Logs;
 import io.quarkus.ts.startstop.utils.MvnCmds;
 import io.quarkus.ts.startstop.utils.OpenTelemetryCollector;
+import io.quarkus.ts.startstop.utils.Timeout;
 import io.quarkus.ts.startstop.utils.UnitTestResource;
 import io.quarkus.ts.startstop.utils.WebpageTester;
 import org.apache.commons.io.FileUtils;
@@ -103,7 +104,7 @@ public class StartStopTest {
             final List<String> buildCommand = getBuildCommand(baseBuildCmd.toArray(new String[0]));
             LOGGER.info("Running " + baseBuildCmd + " in the " + appDir.getAbsolutePath());
 
-            buildService.submit(new Commands.ProcessRunner(appDir, buildLogA, buildCommand, 20));
+            buildService.submit(new Commands.ProcessRunner(appDir, buildLogA, buildCommand, Timeout.ofMinutes(20)));
             appendln(whatIDidReport, "# " + canonicalName + ", " + methodName);
             appendln(whatIDidReport, (new Date()).toString());
             appendln(whatIDidReport, appDir.getAbsolutePath());
@@ -157,7 +158,8 @@ public class StartStopTest {
                 pA = runCommand(runCommand, appDir, runLogA);
 
                 // Test web pages
-                long timeToFirstOKRequest = WebpageTester.testWeb(app.urlContent.urlContent[0][0], 10, app.urlContent.urlContent[0][1], true);
+                long timeToFirstOKRequest = WebpageTester.testWeb(app.urlContent.urlContent[0][0], Timeout.ofSeconds(10),
+                        app.urlContent.urlContent[0][1], true);
 
                 final Process currentProcess = pA;
                 final int runId = i;
@@ -165,7 +167,7 @@ public class StartStopTest {
 
                 LOGGER.info("Testing web page content...");
                 for (String[] urlContent : app.urlContent.urlContent) {
-                    WebpageTester.testWeb(urlContent[0], 5, urlContent[1], false);
+                    WebpageTester.testWeb(urlContent[0], Timeout.ofSeconds(5), urlContent[1], false);
                 }
 
                 LOGGER.info("Terminate and scan logs...");
@@ -178,7 +180,7 @@ public class StartStopTest {
 
                 LOGGER.info("Gonna wait for ports closed...");
                 // Release ports
-                assertTrue(waitForTcpClosed("localhost", parsePort(app.urlContent.urlContent[0][0]), 60),
+                assertTrue(waitForTcpClosed("localhost", parsePort(app.urlContent.urlContent[0][0]), Timeout.ofMinutes(1)),
                         "Main port is still open");
                 if (!skipLogCheck) {
                     checkLog(canonicalName, methodName, app, mvnCmds, runLogA);

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/ibm/CodeQuarkusIbmSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/ibm/CodeQuarkusIbmSiteTest.java
@@ -8,6 +8,7 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
 import com.microsoft.playwright.options.ElementState;
 import io.quarkus.ts.startstop.utils.Commands;
+import io.quarkus.ts.startstop.utils.Timeout;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
@@ -72,7 +73,7 @@ public class CodeQuarkusIbmSiteTest {
 
     @Test
     public void validatePresenceOfIcon(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, Timeout.ofMinutes(1));
         LOGGER.info("Trying to find element: " + elementIconByXpath);
         Locator icon = page.locator(elementIconByXpath);
         assertEquals(1, icon.count(), "Element: " + elementIconByXpath + " is missing!");
@@ -80,7 +81,7 @@ public class CodeQuarkusIbmSiteTest {
 
     @Test
     public void validatePresenceOfTitle(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, Timeout.ofMinutes(1));
         LOGGER.info("Verify page title is: " + elementTitleByText);
         assertEquals(elementTitleByText, page.title(),
                 "Title doesn't match. Found on the web: " + page.title() + ". Expected: " + elementTitleByText);
@@ -88,7 +89,7 @@ public class CodeQuarkusIbmSiteTest {
 
     @Test
     public void validatePresenceOfBrandName(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, Timeout.ofMinutes(1));
         LOGGER.info("Trying to find element: " + elementBrandNameByXpath);
         Locator brandName = page.locator(elementBrandNameByXpath);
         brandName.elementHandle().waitForElementState(ElementState.VISIBLE);
@@ -97,7 +98,7 @@ public class CodeQuarkusIbmSiteTest {
 
     @Test
     public void validatePresenceOfSupportedFlags(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl + "/?e=grpc", 60);
+        Page page = loadPage(webPageUrl + "/?e=grpc", Timeout.ofMinutes(1));
         LOGGER.info("Trying to find element: " + elementSupportedFlagByXpath);
         Locator supportedExtensions = page.locator(elementSupportedFlagByXpath);
         assertTrue(supportedExtensions.count() >= 1, "Element: " + elementSupportedFlagByXpath + " is missing!");
@@ -105,7 +106,7 @@ public class CodeQuarkusIbmSiteTest {
 
     @Test
     public void validatePresenceOfJavaVersionSelect(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, Timeout.ofMinutes(1));
         LOGGER.info("Trying to find element: " + elementJavaVersionSelectByXpath);
         Locator javaVersionSelect = page.locator(elementJavaVersionSelectByXpath);
         assertTrue(javaVersionSelect.count() == 1, "Element: " + elementJavaVersionSelectByXpath + " is missing!");
@@ -117,7 +118,7 @@ public class CodeQuarkusIbmSiteTest {
 
     @Test
     public void validatePresenceOfStreamVersionSelect(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, Timeout.ofMinutes(1));
         LOGGER.info("Trying to find element: " + elementStreamPickerByXpath);
         Locator streamPicker = page.locator(elementStreamPickerByXpath);
         assertTrue(streamPicker.isVisible(), "Element: " + streamPicker + " is missing!");
@@ -137,7 +138,7 @@ public class CodeQuarkusIbmSiteTest {
         // TODO change this to IBM when it have standalone platform name
         Assumptions.assumeTrue(quarkusPlatformVersion.contains("redhat"));
 
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, Timeout.ofMinutes(1));
         LOGGER.info("Trying to find element: " + elementQuarkusPlatformVersionByXpath);
         String quarkusPlatformVersionFromWeb = page.locator(elementQuarkusPlatformVersionByXpath).elementHandle().getAttribute("title");
 
@@ -148,7 +149,7 @@ public class CodeQuarkusIbmSiteTest {
 
     @Test
     public void validateQuarkusSearchForAllSupportedExtensions(TestInfo testInfo) {
-        Page page = loadPageWithExtensions(webPageUrl + "?extension-search=support:*", 60);
+        Page page = loadPageWithExtensions(webPageUrl + "?extension-search=support:*", Timeout.ofMinutes(1));
         showAllExtension(page);
         // Check if the supported extension are visible
         LOGGER.info("Trying to find element: " + elementExtensionByXpath.formatted(QUARKUS_REST_EXTENSION));
@@ -166,7 +167,7 @@ public class CodeQuarkusIbmSiteTest {
 
     @Test
     public void validateQuarkusSearchForAllNotSupportedExtensions(TestInfo testInfo) {
-        Page page = loadPageWithExtensions(webPageUrl + "?extension-search=!support", 60);
+        Page page = loadPageWithExtensions(webPageUrl + "?extension-search=!support", Timeout.ofMinutes(1));
         showAllExtension(page);
         // Check if the supported extension are not visible
         LOGGER.info("Trying to find element: " + elementExtensionByXpath.formatted(QUARKUS_REST_EXTENSION));
@@ -189,7 +190,7 @@ public class CodeQuarkusIbmSiteTest {
         // TODO add `dev-preview` when the code.quarkus is updated
         String[] supportScopes = {"full-support", "tech-preview", "dev-support", "supported-in-jvm", "deprecated"};
 
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, Timeout.ofMinutes(1));
         // The support menu is not visible without clicking at it
         closeIntroductionModalWindow(page);
         page.locator(elementSupportFilterXpath).click();
@@ -218,18 +219,18 @@ public class CodeQuarkusIbmSiteTest {
         page.locator(elementExpandExtensionXpath).click();
     }
 
-    public Page loadPage(String url, int timeoutSeconds) {
-        return loadPageSettingWaitSelector(url, timeoutSeconds, pageLoadedSelector);
+    public Page loadPage(String url, Timeout timeout) {
+        return loadPageSettingWaitSelector(url, timeout, pageLoadedSelector);
     }
 
-    public Page loadPageWithExtensions(String url, int timeoutSeconds) {
-        return loadPageSettingWaitSelector(url, timeoutSeconds, pageWithExtensionLoadedSelector);
+    public Page loadPageWithExtensions(String url, Timeout timeout) {
+        return loadPageSettingWaitSelector(url, timeout, pageWithExtensionLoadedSelector);
     }
 
-    public Page loadPageSettingWaitSelector(String url, int timeoutSeconds, String selector) {
+    public Page loadPageSettingWaitSelector(String url, Timeout timeout, String selector) {
         LOGGER.info("Loading web page " + url);
         Page page = browserContext.newPage(); // this will create new tab inside browser
-        page.setDefaultTimeout(timeoutSeconds * 1000);
+        page.setDefaultTimeout(timeout.toMillis());
         page.navigate(url);
         page.waitForSelector(selector);
         return page;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/redhat/CodeQuarkusRedHatSiteTest.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/redhat/CodeQuarkusRedHatSiteTest.java
@@ -8,6 +8,7 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
 import com.microsoft.playwright.options.ElementState;
 import io.quarkus.ts.startstop.utils.Commands;
+import io.quarkus.ts.startstop.utils.Timeout;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
@@ -72,7 +73,7 @@ public class CodeQuarkusRedHatSiteTest {
 
     @Test
     public void validatePresenceOfIcon(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, Timeout.ofMinutes(1));
         LOGGER.info("Trying to find element: " + elementIconByXpath);
         Locator icon = page.locator(elementIconByXpath);
         assertEquals(1, icon.count(), "Element: " + elementIconByXpath + " is missing!");
@@ -80,7 +81,7 @@ public class CodeQuarkusRedHatSiteTest {
 
     @Test
     public void validatePresenceOfTitle(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, Timeout.ofMinutes(1));
         LOGGER.info("Verify page title is: " + elementTitleByText);
         assertEquals(elementTitleByText, page.title(),
                 "Title doesn't match. Found on the web: " + page.title() + ". Expected: " + elementTitleByText);
@@ -88,7 +89,7 @@ public class CodeQuarkusRedHatSiteTest {
 
     @Test
     public void validatePresenceOfRedHatLogo(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, Timeout.ofMinutes(1));
         LOGGER.info("Trying to find element: " + elementRedHatLogoByXpath);
         Locator redHatLogo = page.locator(elementRedHatLogoByXpath);
         redHatLogo.elementHandle().waitForElementState(ElementState.VISIBLE);
@@ -97,7 +98,7 @@ public class CodeQuarkusRedHatSiteTest {
 
     @Test
     public void validatePresenceOfSupportedFlags(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl + "/?e=grpc", 60);
+        Page page = loadPage(webPageUrl + "/?e=grpc", Timeout.ofMinutes(1));
         LOGGER.info("Trying to find element: " + elementSupportedFlagByXpath);
         Locator supportedExtensions = page.locator(elementSupportedFlagByXpath);
         assertTrue(supportedExtensions.count() >= 1, "Element: " + elementSupportedFlagByXpath + " is missing!");
@@ -105,7 +106,7 @@ public class CodeQuarkusRedHatSiteTest {
 
     @Test
     public void validatePresenceOfJavaVersionSelect(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, Timeout.ofMinutes(1));
         LOGGER.info("Trying to find element: " + elementJavaVersionSelectByXpath);
         Locator javaVersionSelect = page.locator(elementJavaVersionSelectByXpath);
         assertTrue(javaVersionSelect.count() == 1, "Element: " + elementJavaVersionSelectByXpath + " is missing!");
@@ -117,7 +118,7 @@ public class CodeQuarkusRedHatSiteTest {
 
     @Test
     public void validatePresenceOfStreamVersionSelect(TestInfo testInfo) {
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, Timeout.ofMinutes(1));
         LOGGER.info("Trying to find element: " + elementStreamPickerByXpath);
         Locator streamPicker = page.locator(elementStreamPickerByXpath);
         assertTrue(streamPicker.isVisible(), "Element: " + streamPicker + " is missing!");
@@ -136,7 +137,7 @@ public class CodeQuarkusRedHatSiteTest {
         String quarkusPlatformVersion = getQuarkusVersion();
         Assumptions.assumeTrue(quarkusPlatformVersion.contains("redhat"));
 
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, Timeout.ofMinutes(1));
         LOGGER.info("Trying to find element: " + elementQuarkusPlatformVersionByXpath);
         String quarkusPlatformVersionFromWeb = page.locator(elementQuarkusPlatformVersionByXpath).elementHandle().getAttribute("title");
 
@@ -147,7 +148,7 @@ public class CodeQuarkusRedHatSiteTest {
 
     @Test
     public void validateQuarkusSearchForAllSupportedExtensions(TestInfo testInfo) {
-        Page page = loadPageWithExtensions(webPageUrl + "?extension-search=support:*", 60);
+        Page page = loadPageWithExtensions(webPageUrl + "?extension-search=support:*", Timeout.ofMinutes(1));
 
         showAllExtension(page);
 
@@ -167,7 +168,7 @@ public class CodeQuarkusRedHatSiteTest {
 
     @Test
     public void validateQuarkusSearchForAllNotSupportedExtensions(TestInfo testInfo) {
-        Page page = loadPageWithExtensions(webPageUrl + "?extension-search=!support", 60);
+        Page page = loadPageWithExtensions(webPageUrl + "?extension-search=!support", Timeout.ofMinutes(1));
 
         showAllExtension(page);
         // Check if the supported extension are not visible
@@ -191,7 +192,7 @@ public class CodeQuarkusRedHatSiteTest {
         // TODO add `dev-preview` when the code.quarkus is updated
         String[] supportScopes = {"full-support", "tech-preview", "dev-support", "supported-in-jvm", "deprecated"};
 
-        Page page = loadPage(webPageUrl, 60);
+        Page page = loadPage(webPageUrl, Timeout.ofMinutes(1));
         // The support menu is not visible without clicking at it
         closeIntroductionModalWindow(page);
         page.locator(elementSupportFilterXpath).click();
@@ -217,18 +218,18 @@ public class CodeQuarkusRedHatSiteTest {
         page.locator(elementExpandExtensionXpath).click();
     }
 
-    public Page loadPage(String url, int timeoutSeconds) {
-        return loadPageSettingWaitSelector(url, timeoutSeconds, pageLoadedSelector);
+    public Page loadPage(String url, Timeout timeout) {
+        return loadPageSettingWaitSelector(url, timeout, pageLoadedSelector);
     }
 
-    public Page loadPageWithExtensions(String url, int timeoutSeconds) {
-        return loadPageSettingWaitSelector(url, timeoutSeconds, pageWithExtensionLoadedSelector);
+    public Page loadPageWithExtensions(String url, Timeout timeout) {
+        return loadPageSettingWaitSelector(url, timeout, pageWithExtensionLoadedSelector);
     }
 
-    public Page loadPageSettingWaitSelector(String url, int timeoutSeconds, String selector) {
+    public Page loadPageSettingWaitSelector(String url, Timeout timeout, String selector) {
         LOGGER.info("Loading web page " + url);
         Page page = browserContext.newPage(); // this will create new tab inside browser
-        page.setDefaultTimeout(timeoutSeconds * 1000);
+        page.setDefaultTimeout(timeout.toMillis());
         page.navigate(url);
         page.waitForSelector(selector);
         return page;

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Commands.java
@@ -399,12 +399,11 @@ public class Commands {
         transformer.transform(new DOMSource(doc), new StreamResult(pomFile));
     }
 
-    public static boolean waitForTcpClosed(String host, int port, long loopTimeoutS) throws InterruptedException, UnknownHostException {
+    public static boolean waitForTcpClosed(String host, int port, Timeout timeout) throws InterruptedException, UnknownHostException {
         InetAddress address = InetAddress.getByName(host);
-        long now = System.currentTimeMillis();
-        long startTime = now;
         InetSocketAddress socketAddr = new InetSocketAddress(address, port);
-        while (now - startTime < 1000 * loopTimeoutS) {
+        TimeoutMeasure measure = timeout.measure();
+        while (measure.hasTimeLeft()) {
             try (Socket socket = new Socket()) {
                 // If it let's you write something there, it is still ready.
                 socket.connect(socketAddr, 1000);
@@ -418,7 +417,6 @@ public class Commands {
                 return true;
             }
             Thread.sleep(1000);
-            now = System.currentTimeMillis();
         }
         return false;
     }
@@ -714,13 +712,13 @@ public class Commands {
         final File directory;
         final File log;
         final List<String> command;
-        final long timeoutMinutes;
+        final Timeout timeout;
 
-        public ProcessRunner(File directory, File log, List<String> command, long timeoutMinutes) {
+        public ProcessRunner(File directory, File log, List<String> command, Timeout timeout) {
             this.directory = directory;
             this.log = log;
             this.command = command;
-            this.timeoutMinutes = timeoutMinutes;
+            this.timeout = timeout;
         }
 
         @Override
@@ -739,7 +737,7 @@ public class Commands {
                 e.printStackTrace();
             }
             try {
-                Objects.requireNonNull(p).waitFor(timeoutMinutes, TimeUnit.MINUTES);
+                Objects.requireNonNull(p).waitFor(timeout.toSeconds(), TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Timeout.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/Timeout.java
@@ -1,0 +1,85 @@
+package io.quarkus.ts.startstop.utils;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+public final class Timeout {
+    private static final double MULTIPLIER = Double.parseDouble(System.getProperty("ts.timeout.multiplier", "1.0"));
+
+    public static Timeout zero() {
+        return new Timeout(0);
+    }
+
+    public static Timeout of(Duration duration) {
+        return new Timeout(duration.toNanos());
+    }
+
+    public static Timeout ofMinutes(int minutes) {
+        return new Timeout(TimeUnit.MINUTES.toNanos(minutes));
+    }
+
+    public static Timeout ofSeconds(int seconds) {
+        return new Timeout(TimeUnit.SECONDS.toNanos(seconds));
+    }
+
+    public static Timeout ofMillis(int millis) {
+        return new Timeout(TimeUnit.MILLISECONDS.toNanos(millis));
+    }
+
+    private final long nanos;
+
+    private Timeout(long nanos) {
+        if (nanos < 0) {
+            throw new IllegalArgumentException("Timeout must not be negative");
+        }
+        this.nanos = (long) (MULTIPLIER * nanos);
+    }
+
+    public long toSeconds() {
+        return TimeUnit.NANOSECONDS.toSeconds(nanos);
+    }
+
+    public long toMillis() {
+        return TimeUnit.NANOSECONDS.toMillis(nanos);
+    }
+
+    public long toNanos() {
+        return nanos;
+    }
+
+    public Duration toDuration() {
+        return Duration.ofNanos(nanos);
+    }
+
+    public TimeoutMeasure measure() {
+        return new TimeoutMeasure(nanos);
+    }
+
+    @Override
+    public String toString() {
+        if (nanos <= 0) {
+            return "0ms";
+        }
+
+        long totalMillis = nanos / 1_000_000L;
+        if (totalMillis == 0) {
+            return "0ms";
+        }
+
+        long minutes = totalMillis / 60_000L;
+        long seconds = (totalMillis % 60_000L) / 1_000L;
+        long millis = totalMillis % 1_000L;
+
+        StringBuilder result = new StringBuilder();
+        if (minutes > 0) {
+            result.append(minutes).append("m ");
+        }
+        if (seconds > 0) {
+            result.append(seconds).append("s ");
+        }
+        if (millis > 0 || result.isEmpty()) {
+            result.append(millis).append("ms");
+        }
+        return result.toString().trim();
+    }
+}

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/TimeoutMeasure.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/TimeoutMeasure.java
@@ -1,0 +1,29 @@
+package io.quarkus.ts.startstop.utils;
+
+import java.time.Duration;
+
+public final class TimeoutMeasure {
+    private final long start;
+    private final long duration;
+
+    TimeoutMeasure(long durationInNanos) {
+        this.start = System.nanoTime();
+        this.duration = durationInNanos;
+    }
+
+    public boolean hasPassed() {
+        return (System.nanoTime() - start) >= duration;
+    }
+
+    public boolean hasTimeLeft() {
+        return !hasPassed();
+    }
+
+    public long elapsedMillis() {
+        return (System.nanoTime() - start) / 1_000_000L;
+    }
+
+    public Duration elapsedTime() {
+        return Duration.ofNanos(System.nanoTime() - start);
+    }
+}

--- a/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WebpageTester.java
+++ b/testsuite/src/it/java/io/quarkus/ts/startstop/utils/WebpageTester.java
@@ -20,26 +20,23 @@ public class WebpageTester {
      * Patiently try to wait for a web page and examine it
      *
      * @param url             address
-     * @param timeoutS        in seconds
+     * @param timeout         timeout
      * @param stringToLookFor string must be present on the page
+     * @param measureTime     whether to try to measure time as precisely as possible
+     * @return the time it took for the {@code url} to contain the given {@code stringToLookFor}
      */
-    public static long testWeb(String url, long timeoutS, String stringToLookFor, boolean measureTime) throws InterruptedException, IOException {
+    public static long testWeb(String url, Timeout timeout, String stringToLookFor, boolean measureTime) throws InterruptedException, IOException {
         if (StringUtils.isBlank(url)) {
             throw new IllegalArgumentException("url must not be empty");
-        }
-        if (timeoutS < 0) {
-            throw new IllegalArgumentException("timeoutS must be positive");
         }
         if (StringUtils.isBlank(stringToLookFor)) {
             throw new IllegalArgumentException("stringToLookFor must contain a non-empty string");
         }
         String webPage = "";
 
-        long now = System.currentTimeMillis();
-        final long startTime = now;
         boolean found = false;
-        long foundTimestamp = -1L;
-        while (now - startTime < 1000 * timeoutS) {
+        TimeoutMeasure measure = timeout.measure();
+        while (measure.hasTimeLeft()) {
             URLConnection c = URI.create(url).toURL().openConnection();
             c.setRequestProperty("Accept", "*/*");
             c.setConnectTimeout(500);
@@ -52,9 +49,6 @@ public class WebpageTester {
             }
             if (webPage.contains(stringToLookFor)) {
                 found = true;
-                if (measureTime) {
-                    foundTimestamp = System.currentTimeMillis();
-                }
                 break;
             }
             if (!measureTime) {
@@ -62,16 +56,15 @@ public class WebpageTester {
             } else {
                 LockSupport.parkNanos(100000);
             }
-            now = System.currentTimeMillis();
         }
 
-        String failureMessage = "Timeout " + timeoutS + "s was reached. " +
+        String failureMessage = "Timeout " + timeout + " was reached. " +
                 (StringUtils.isNotBlank(webPage) ? webPage + " must contain string: " : "Empty webpage does not contain string: ") +
                 "`" + stringToLookFor + "'";
         if (!found) {
             LOGGER.info(failureMessage);
         }
         assertTrue(found, failureMessage);
-        return foundTimestamp - startTime;
+        return measure.elapsedMillis();
     }
 }


### PR DESCRIPTION
This commit replaces naive timeout handling with a proper domain model. The `Timeout` class holds immutable timeout configuration, including a timeout multiplier for slow environments (read from a system property). It allows starting a `TimeoutMeasure`, which measures time starting from its creation. It allows determining whether the timeout has passed or not, and may return the elapsed time.

The most important places where naive timeouts were used are converted to use `Timeout` now, but there likely are some other places that still use naive timeouts. Those may be converted later, when needed.